### PR TITLE
Fixed "no services added" with javascript code block.

### DIFF
--- a/frontend/templates/core/pages/invoices/create/_services_table_body.html
+++ b/frontend/templates/core/pages/invoices/create/_services_table_body.html
@@ -18,7 +18,7 @@
             £{{ row.total_price | intcomma }}
         </td>
         <td>
-            <button type="button" class="btn btn-outline-error btn-xs" hx-target="closest tr" hx-delete="{% url "api v1 invoices create services remove" %}">
+            <button type="button" class="btn btn-outline-error btn-xs" hx-swap="outerHTML" hx-target="closest tr" hx-delete="{% url "api v1 invoices create services remove" %}">
                 <i class="fa-solid fa-trash-can pe-2"></i>
                 Delete
             </button>
@@ -29,4 +29,13 @@
         <td colspan="5">No services added</td>
     </tr>
 {% endfor %}
-{#<input class="modal-state" id="modal-1" type="checkbox" id="modal-checkbox"/>#}
+
+<script>
+    document.addEventListener('htmx:afterRequest', function (event) {
+        var container = document.getElementById('services_table_body');
+        var rows = container.querySelectorAll('tr');
+        if (rows.length === 0) {
+            container.innerHTML = '<tr><td colspan="5">No services added</td></tr>';
+        }
+    });
+</script>

--- a/frontend/templates/core/pages/invoices/create/create.html
+++ b/frontend/templates/core/pages/invoices/create/create.html
@@ -89,7 +89,7 @@
                         </tr>
                         </thead>
                         <tbody id="services_table_body">
-                        {% include 'core/pages/invoices/create/_services_table_body.html' %}
+                            {% include 'core/pages/invoices/create/_services_table_body.html' %}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
---
title: Issue #71 | No services added text not showing up
---

## What type of PR is this? (delete all that don't apply)

- 🐛 Bug Fix

## Description

Fixed the "no services added" text that disappears when HX-delete deletes all rows, now have a JS event handler to add text if no items

## Related Tickets & Documents

- Closes #71