### PR TITLE
Adding invoice editing functionality to MyFinances 

### DIFF
--- a/backend/api/invoices/edit.py
+++ b/backend/api/invoices/edit.py
@@ -9,34 +9,33 @@ from datetime import datetime
 
 @require_http_methods(["POST"])
 def edit_invoice(request: HttpRequest):
-
     try:
-        invoice = Invoice.objects.get(id=request.POST.get('invoice_id'))
+        invoice = Invoice.objects.get(id=request.POST.get("invoice_id"))
     except:
         return JsonResponse({"message": "Invoice not found"}, status=404)
 
     attributes_to_updates = {
-        "date_due": datetime.strptime(request.POST.get('date_due'), '%Y-%m-%d').date(),
-        "date_issued": request.POST.get('date_issued'),
-        "client_name": request.POST.get('to_name'),
-        "client_company": request.POST.get('to_company'),
-        "client_address": request.POST.get('to_address'),
-        "client_city": request.POST.get('to_city'),
-        "client_county": request.POST.get('to_county'),
-        "client_country": request.POST.get('to_country'),
-        "self_name": request.POST.get('from_name'),
-        "self_company": request.POST.get('from_company'),
-        "self_address": request.POST.get('from_address'),
-        "self_city": request.POST.get('from_city'),
-        "self_county": request.POST.get('from_county'),
-        "self_country": request.POST.get('from_country'),
-        "notes": request.POST.get('notes'),
-        "invoice_number": request.POST.get('invoice_number'),
-        "vat_number": request.POST.get('vat_number'),
-        "reference": request.POST.get('reference'),
-        "sort_code": request.POST.get('sort_code'),
-        "account_number": request.POST.get('account_number'),
-        "account_holder_name": request.POST.get('account_holder_name')
+        "date_due": datetime.strptime(request.POST.get("date_due"), "%Y-%m-%d").date(),
+        "date_issued": request.POST.get("date_issued"),
+        "client_name": request.POST.get("to_name"),
+        "client_company": request.POST.get("to_company"),
+        "client_address": request.POST.get("to_address"),
+        "client_city": request.POST.get("to_city"),
+        "client_county": request.POST.get("to_county"),
+        "client_country": request.POST.get("to_country"),
+        "self_name": request.POST.get("from_name"),
+        "self_company": request.POST.get("from_company"),
+        "self_address": request.POST.get("from_address"),
+        "self_city": request.POST.get("from_city"),
+        "self_county": request.POST.get("from_county"),
+        "self_country": request.POST.get("from_country"),
+        "notes": request.POST.get("notes"),
+        "invoice_number": request.POST.get("invoice_number"),
+        "vat_number": request.POST.get("vat_number"),
+        "reference": request.POST.get("reference"),
+        "sort_code": request.POST.get("sort_code"),
+        "account_number": request.POST.get("account_number"),
+        "account_holder_name": request.POST.get("account_holder_name"),
     }
 
     for column_name, new_value in attributes_to_updates.items():

--- a/backend/api/invoices/edit.py
+++ b/backend/api/invoices/edit.py
@@ -4,24 +4,45 @@ from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 
 from backend.models import Invoice
+from datetime import datetime
 
 
-@require_http_methods(["EDIT"])
+@require_http_methods(["POST"])
 def edit_invoice(request: HttpRequest):
-    edit_items = QueryDict(request.body)
-    print("edit items", edit_items)
-
-    invoice = edit_items.get("invoice")
 
     try:
-        invoice = Invoice.objects.get(id=invoice)
+        invoice = Invoice.objects.get(id=request.POST.get('invoice_id'))
     except:
         return JsonResponse({"message": "Invoice not found"}, status=404)
 
-    if not invoice or invoice.user != request.user:
-        return JsonResponse({"message": "Invoice not found"}, status=404)
+    attributes_to_updates = {
+        "date_due": datetime.strptime(request.POST.get('date_due'), '%Y-%m-%d').date(),
+        "date_issued": request.POST.get('date_issued'),
+        "client_name": request.POST.get('to_name'),
+        "client_company": request.POST.get('to_company'),
+        "client_address": request.POST.get('to_address'),
+        "client_city": request.POST.get('to_city'),
+        "client_county": request.POST.get('to_county'),
+        "client_country": request.POST.get('to_country'),
+        "self_name": request.POST.get('from_name'),
+        "self_company": request.POST.get('from_company'),
+        "self_address": request.POST.get('from_address'),
+        "self_city": request.POST.get('from_city'),
+        "self_county": request.POST.get('from_county'),
+        "self_country": request.POST.get('from_country'),
+        "notes": request.POST.get('notes'),
+        "invoice_number": request.POST.get('invoice_number'),
+        "vat_number": request.POST.get('vat_number'),
+        "reference": request.POST.get('reference'),
+        "sort_code": request.POST.get('sort_code'),
+        "account_number": request.POST.get('account_number'),
+        "account_holder_name": request.POST.get('account_holder_name')
+    }
 
-    invoice.edit()
+    for column_name, new_value in attributes_to_updates.items():
+        setattr(invoice, column_name, new_value)
+
+    invoice.save()
 
     if request.htmx:
         messages.success(request, "Invoice edited")

--- a/backend/api/invoices/edit.py
+++ b/backend/api/invoices/edit.py
@@ -1,0 +1,30 @@
+from django.contrib import messages
+from django.http import HttpRequest, JsonResponse, QueryDict
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from backend.models import Invoice
+
+
+@require_http_methods(["EDIT"])
+def edit_invoice(request: HttpRequest):
+    edit_items = QueryDict(request.body)
+    print("edit items", edit_items)
+
+    invoice = edit_items.get("invoice")
+
+    try:
+        invoice = Invoice.objects.get(id=invoice)
+    except:
+        return JsonResponse({"message": "Invoice not found"}, status=404)
+
+    if not invoice or invoice.user != request.user:
+        return JsonResponse({"message": "Invoice not found"}, status=404)
+
+    invoice.edit()
+
+    if request.htmx:
+        messages.success(request, "Invoice edited")
+        return render(request, "partials/base/toasts.html")
+
+    return JsonResponse({"message": "Invoice successfully edited"}, status=200)

--- a/backend/api/invoices/fetch.py
+++ b/backend/api/invoices/fetch.py
@@ -57,6 +57,8 @@ def fetch_all_invoices(request: HttpRequest):
         )
     )
 
+    
+
     # Initialize context variables
     context["selected_filters"] = []
     context["all_filters"] = {
@@ -96,6 +98,12 @@ def fetch_all_invoices(request: HttpRequest):
         # Combine OR conditions for each filter type with AND
         or_conditions &= or_conditions_filter
 
+    #check/update payment status to make sure it is correct before invoices are filtered and displayed  
+    for items in invoices:
+        if (items.date_due and timezone.now().date() > items.date_due) and items.payment_status == "pending":
+            items.payment_status = "overdue"
+            items.save()
+
     # Apply OR conditions to the invoices queryset
     invoices = invoices.filter(or_conditions)
 
@@ -105,9 +113,6 @@ def fetch_all_invoices(request: HttpRequest):
         context["sort"] = sort_by
 
     # Add invoices to the context
-    for items in invoices:
-        if (items.date_due and timezone.now().date() > items.date_due) and items.payment_status == "pending":
-            items.payment_status = "overdue"
             
     context["invoices"] = invoices
 

--- a/backend/api/invoices/fetch.py
+++ b/backend/api/invoices/fetch.py
@@ -57,8 +57,6 @@ def fetch_all_invoices(request: HttpRequest):
         )
     )
 
-    
-
     # Initialize context variables
     context["selected_filters"] = []
     context["all_filters"] = {
@@ -98,12 +96,16 @@ def fetch_all_invoices(request: HttpRequest):
         # Combine OR conditions for each filter type with AND
         or_conditions &= or_conditions_filter
 
-    #check/update payment status to make sure it is correct before invoices are filtered and displayed  
+    # check/update payment status to make sure it is correct before invoices are filtered and displayed
     for items in invoices:
-        if (items.date_due and timezone.now().date() > items.date_due) and items.payment_status == "pending":
+        if (
+            items.date_due and timezone.now().date() > items.date_due
+        ) and items.payment_status == "pending":
             items.payment_status = "overdue"
             items.save()
-        if (items.date_due and timezone.now().date() < items.date_due) and items.payment_status == "overdue":
+        if (
+            items.date_due and timezone.now().date() < items.date_due
+        ) and items.payment_status == "overdue":
             items.payment_status = "pending"
             items.save()
 
@@ -116,7 +118,7 @@ def fetch_all_invoices(request: HttpRequest):
         context["sort"] = sort_by
 
     # Add invoices to the context
-            
+
     context["invoices"] = invoices
 
     # Render the HTMX response

--- a/backend/api/invoices/fetch.py
+++ b/backend/api/invoices/fetch.py
@@ -103,6 +103,9 @@ def fetch_all_invoices(request: HttpRequest):
         if (items.date_due and timezone.now().date() > items.date_due) and items.payment_status == "pending":
             items.payment_status = "overdue"
             items.save()
+        if (items.date_due and timezone.now().date() < items.date_due) and items.payment_status == "overdue":
+            items.payment_status = "pending"
+            items.save()
 
     # Apply OR conditions to the invoices queryset
     invoices = invoices.filter(or_conditions)

--- a/backend/api/invoices/urls.py
+++ b/backend/api/invoices/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import fetch, delete
+from . import fetch, delete, edit
 from .create import set_destination
 from .create.services import add, remove
 
@@ -29,6 +29,11 @@ urlpatterns = [
         "delete/",
         delete.delete_invoice,
         name="delete",
+    ),
+    path(
+        "edit/",
+        edit.edit_invoice,
+        name="edit",
     ),
     path("fetch/", fetch.fetch_all_invoices, name="fetch"),
 ]

--- a/backend/models.py
+++ b/backend/models.py
@@ -9,7 +9,6 @@ from django.utils.crypto import get_random_string
 from shortuuid.django_fields import ShortUUIDField
 
 
-
 class CustomUserManager(UserManager):
     def get_queryset(self):
         return super().get_queryset().select_related("user_profile")
@@ -161,7 +160,7 @@ class InvoiceItem(models.Model):
     def __str__(self):
         return self.description
 
-    
+
 class Invoice(models.Model):
     STATUS_CHOICES = (
         ("pending", "Pending"),
@@ -210,11 +209,15 @@ class Invoice(models.Model):
 
     @property
     def dynamic_payment_status(self):
-        if self.date_due and timezone.now().date() > self.date_due and self.payment_status == "pending":
+        if (
+            self.date_due
+            and timezone.now().date() > self.date_due
+            and self.payment_status == "pending"
+        ):
             return "overdue"
         else:
             return self.payment_status
-        
+
     def __str__(self):
         invoice_id = self.invoice_id or self.id
         if self.client_name:

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import re_path as url, path, include
 from django.views.static import serve
+from .api.invoices import edit
 
 from backend.views.core import (
     other,
@@ -115,9 +116,14 @@ urlpatterns = [
         invoices.create.create_invoice_page,
         name="invoices dashboard create",
     ),
+    #path(
+    #    "dashboard/invoices/<str:id>",
+    #    invoices.dashboard.invoices_dashboard_id,
+    #    name="invoices dashboard edit",
+    #),
     path(
-        "dashboard/invoices/<str:id>",
-        invoices.dashboard.invoices_dashboard_id,
+        "dashboard/invoices/edit/<str:id>",
+        edit.edit_invoice,
         name="invoices dashboard edit",
     ),
     # path('dashboard/invoices/<str:id>/edit', invoices.dashboard.invoices_dash~board_id, name='invoices dashboard'),

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import re_path as url, path, include
 from django.views.static import serve
-from .api.invoices import edit
+from .views.core.invoices import edit
 
 from backend.views.core import (
     other,
@@ -123,7 +123,7 @@ urlpatterns = [
     #),
     path(
         "dashboard/invoices/edit/<str:id>",
-        invoices.create.edit_invoice_page,
+        invoices.edit.edit_invoice_page,
         #invoices.edit.invoice_edit_page_get,
         name="invoices dashboard edit",
     ),

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -116,15 +116,15 @@ urlpatterns = [
         invoices.create.create_invoice_page,
         name="invoices dashboard create",
     ),
-    #path(
+    # path(
     #    "dashboard/invoices/<str:id>",
     #    invoices.dashboard.invoices_dashboard_id,
     #    name="invoices dashboard edit",
-    #),
+    # ),
     path(
         "dashboard/invoices/edit/<str:id>",
         invoices.edit.edit_invoice_page,
-        #invoices.edit.invoice_edit_page_get,
+        # invoices.edit.invoice_edit_page_get,
         name="invoices dashboard edit",
     ),
     # path('dashboard/invoices/<str:id>/edit', invoices.dashboard.invoices_dash~board_id, name='invoices dashboard'),

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -123,7 +123,8 @@ urlpatterns = [
     #),
     path(
         "dashboard/invoices/edit/<str:id>",
-        edit.edit_invoice,
+        invoices.create.edit_invoice_page,
+        #invoices.edit.invoice_edit_page_get,
         name="invoices dashboard edit",
     ),
     # path('dashboard/invoices/<str:id>/edit', invoices.dashboard.invoices_dash~board_id, name='invoices dashboard'),

--- a/backend/views/core/invoices/create.py
+++ b/backend/views/core/invoices/create.py
@@ -27,7 +27,7 @@ def invoice_page_post(request: HttpRequest):
 
     invoice = Invoice.objects.create(
         user=request.user,
-        date_due=datetime.strptime(request.POST.get("date_due"), '%Y-%m-%d').date(),
+        date_due=datetime.strptime(request.POST.get("date_due"), "%Y-%m-%d").date(),
         date_issued=request.POST.get("date_issued"),
         client_name=request.POST.get("to_name"),
         client_company=request.POST.get("to_company"),

--- a/backend/views/core/invoices/create.py
+++ b/backend/views/core/invoices/create.py
@@ -64,3 +64,10 @@ def create_invoice_page(request: HttpRequest):
     if request.method == "POST":
         return invoice_page_post(request)
     return invoice_page_get(request)
+
+
+@require_http_methods(["GET", "POST"])
+def edit_invoice_page(request: HttpRequest):
+    if request.method == "POST":
+        return invoice_page_post(request)
+    return invoice_page_get(request)

--- a/backend/views/core/invoices/edit.py
+++ b/backend/views/core/invoices/edit.py
@@ -1,0 +1,67 @@
+from django.contrib import messages
+from django.http import HttpRequest, JsonResponse, QueryDict
+from django.shortcuts import render
+from django.views.decorators.http import require_http_methods
+
+from backend.models import Invoice
+from datetime import datetime
+
+
+def invoice_edit_page_get(request, id):
+    context = {"type": "edit"}
+    return render(request, "pages/invoices/edit/edit.html", context)
+
+
+@require_http_methods(["EDIT"])
+def edit_invoice(request: HttpRequest):
+
+    edit_items = QueryDict(request.body)
+    invoice = edit_items.get("invoice")
+
+    try:
+        invoice = Invoice.objects.get(id=request.POST.get('invoice_id'))
+    except:
+        return JsonResponse({"message": "Invoice not found"}, status=404)
+
+    attributes_to_updates = {
+        "date_due": datetime.strptime(request.POST.get('date_due'), '%Y-%m-%d').date(),
+        "date_issued": request.POST.get('date_issued'),
+        "client_name": request.POST.get('to_name'),
+        "client_company": request.POST.get('to_company'),
+        "client_address": request.POST.get('to_address'),
+        "client_city": request.POST.get('to_city'),
+        "client_county": request.POST.get('to_county'),
+        "client_country": request.POST.get('to_country'),
+        "self_name": request.POST.get('from_name'),
+        "self_company": request.POST.get('from_company'),
+        "self_address": request.POST.get('from_address'),
+        "self_city": request.POST.get('from_city'),
+        "self_county": request.POST.get('from_county'),
+        "self_country": request.POST.get('from_country'),
+        "notes": request.POST.get('notes'),
+        "invoice_number": request.POST.get('invoice_number'),
+        "vat_number": request.POST.get('vat_number'),
+        "reference": request.POST.get('reference'),
+        "sort_code": request.POST.get('sort_code'),
+        "account_number": request.POST.get('account_number'),
+        "account_holder_name": request.POST.get('account_holder_name')
+    }
+
+    for column_name, new_value in attributes_to_updates.items():
+        setattr(invoice, column_name, new_value)
+
+    invoice.save()
+
+    if request.htmx:
+        messages.success(request, "Invoice edited")
+        return render(request, "partials/base/toasts.html")
+
+    return JsonResponse({"message": "Invoice successfully edited"}, status=200)
+
+
+
+@require_http_methods(["GET", "POST"])
+def edit_invoice_page(request: HttpRequest, id):
+    if request.method == "POST":
+        return edit_invoice(request)
+    return invoice_edit_page_get(request, id)

--- a/backend/views/core/invoices/edit.py
+++ b/backend/views/core/invoices/edit.py
@@ -12,14 +12,11 @@ def invoice_edit_page_get(request, id):
     return render(request, "pages/invoices/edit/edit.html", context)
 
 
-@require_http_methods(["EDIT"])
-def edit_invoice(request: HttpRequest):
-
-    edit_items = QueryDict(request.body)
-    invoice = edit_items.get("invoice")
+@require_http_methods(["POST"])
+def edit_invoice(request: HttpRequest, invoice_id):
 
     try:
-        invoice = Invoice.objects.get(id=request.POST.get('invoice_id'))
+        invoice = Invoice.objects.get(id=invoice_id)
     except:
         return JsonResponse({"message": "Invoice not found"}, status=404)
 
@@ -63,5 +60,5 @@ def edit_invoice(request: HttpRequest):
 @require_http_methods(["GET", "POST"])
 def edit_invoice_page(request: HttpRequest, id):
     if request.method == "POST":
-        return edit_invoice(request)
+        return edit_invoice(request,id)
     return invoice_edit_page_get(request, id)

--- a/backend/views/core/invoices/edit.py
+++ b/backend/views/core/invoices/edit.py
@@ -6,42 +6,71 @@ from django.views.decorators.http import require_http_methods
 from backend.models import Invoice
 from datetime import datetime
 
+# RELATED PATH FILES : \frontend\templates\pages\invoices\dashboard\_fetch_body.html, \backend\urls.py
 
-def invoice_edit_page_get(request, id):
+
+# Function that takes an invoice object and makes a dict of its attributes
+def invoice_get_existing_data(invoice_obj):
+    stored_data = {
+        "og_name": invoice_obj.self_name,
+        "og_company": invoice_obj.self_company,
+        "og_address": invoice_obj.self_address,
+        "og_city": invoice_obj.self_city,
+        "og_county": invoice_obj.self_county,
+        "og_country": invoice_obj.self_country,
+        "og_cilent_name": invoice_obj.client_name,
+        "og_cilent_company": invoice_obj.client_company,
+        "og_cilent_address": invoice_obj.client_address,
+        "og_cilent_city": invoice_obj.client_city,
+        "og_cilent_county": invoice_obj.client_county,
+        "og_cilent_country": invoice_obj.client_country,
+    }
+    return stored_data
+
+
+# gets invoice object from invoice id, convert obj to dict, and renders edit.html while passing the stored invoice values to frontend
+def invoice_edit_page_get(request, invoice_id):
     context = {"type": "edit"}
-    return render(request, "pages/invoices/edit/edit.html", context)
+    try:
+        invoice = Invoice.objects.get(id=invoice_id)
+    except:
+        return JsonResponse({"message": "Invoice not found"}, status=404)
+
+    # use to populate fields with existing data in edit_from_destination.html AND edit_to_destination.html
+    data_to_populate = invoice_get_existing_data(invoice)
+    return render(request, "pages/invoices/edit/edit.html", data_to_populate)
 
 
+# when user changes/modifies any of the fields with new information (during edit invoice)
 @require_http_methods(["POST"])
 def edit_invoice(request: HttpRequest, invoice_id):
-
     try:
         invoice = Invoice.objects.get(id=invoice_id)
     except:
         return JsonResponse({"message": "Invoice not found"}, status=404)
 
     attributes_to_updates = {
-        "date_due": datetime.strptime(request.POST.get('date_due'), '%Y-%m-%d').date(),
-        "date_issued": request.POST.get('date_issued'),
-        "client_name": request.POST.get('to_name'),
-        "client_company": request.POST.get('to_company'),
-        "client_address": request.POST.get('to_address'),
-        "client_city": request.POST.get('to_city'),
-        "client_county": request.POST.get('to_county'),
-        "client_country": request.POST.get('to_country'),
-        "self_name": request.POST.get('from_name'),
-        "self_company": request.POST.get('from_company'),
-        "self_address": request.POST.get('from_address'),
-        "self_city": request.POST.get('from_city'),
-        "self_county": request.POST.get('from_county'),
-        "self_country": request.POST.get('from_country'),
-        "notes": request.POST.get('notes'),
-        "invoice_number": request.POST.get('invoice_number'),
-        "vat_number": request.POST.get('vat_number'),
-        "reference": request.POST.get('reference'),
-        "sort_code": request.POST.get('sort_code'),
-        "account_number": request.POST.get('account_number'),
-        "account_holder_name": request.POST.get('account_holder_name')
+        "date_due": datetime.strptime(request.POST.get("date_due"), "%Y-%m-%d").date(),
+        "date_issued": request.POST.get("date_issued"),
+        "client_name": request.POST.get("to_name"),
+        "client_company": request.POST.get("to_company"),
+        "client_address": request.POST.get("to_address"),
+        "client_city": request.POST.get("to_city"),
+        "client_county": request.POST.get("to_county"),
+        "client_country": request.POST.get("to_country"),
+        "self_name": request.POST.get("from_name"),
+        "self_company": request.POST.get("from_company"),
+        "self_address": request.POST.get("from_address"),
+        "self_city": request.POST.get("from_city"),
+        "self_county": request.POST.get("from_county"),
+        "self_country": request.POST.get("from_country"),
+        "notes": request.POST.get("notes"),
+        "invoice_number": request.POST.get("invoice_number"),
+        "vat_number": request.POST.get("vat_number"),
+        "reference": request.POST.get("reference"),
+        "sort_code": request.POST.get("sort_code"),
+        "account_number": request.POST.get("account_number"),
+        "account_holder_name": request.POST.get("account_holder_name"),
     }
 
     for column_name, new_value in attributes_to_updates.items():
@@ -54,12 +83,12 @@ def edit_invoice(request: HttpRequest, invoice_id):
         return render(request, "partials/base/toasts.html")
 
     return render(request, "pages/invoices/dashboard/dashboard.html")
-    #return JsonResponse({"message": "Invoice successfully edited"}, status=200)
+    # return JsonResponse({"message": "Invoice successfully edited"}, status=200)
 
 
-
+# decorator & view function for rendering page and updating invoice items in the backend
 @require_http_methods(["GET", "POST"])
 def edit_invoice_page(request: HttpRequest, id):
     if request.method == "POST":
-        return edit_invoice(request,id)
+        return edit_invoice(request, id)
     return invoice_edit_page_get(request, id)

--- a/backend/views/core/invoices/edit.py
+++ b/backend/views/core/invoices/edit.py
@@ -53,7 +53,8 @@ def edit_invoice(request: HttpRequest, invoice_id):
         messages.success(request, "Invoice edited")
         return render(request, "partials/base/toasts.html")
 
-    return JsonResponse({"message": "Invoice successfully edited"}, status=200)
+    return render(request, "pages/invoices/dashboard/dashboard.html")
+    #return JsonResponse({"message": "Invoice successfully edited"}, status=200)
 
 
 

--- a/frontend/templates/pages/invoices/dashboard/_fetch_body.html
+++ b/frontend/templates/pages/invoices/dashboard/_fetch_body.html
@@ -58,24 +58,23 @@
                             Manage Access
                         </a>
                     </li>
-                    <div class="tooltip tooltip-left" data-tip="These actions aren't yet added.">
-                        <li class="disabled">
-                            <a href="">
-                                <i class="fa-solid fa-regular fa-pencil"></i>
-                                Edit
-                            </a>
-                        </li>
-                        <li>
-                            <button hx-delete="{% url 'api:invoices:delete' %}"
+                    
+                    <li>
+                        <a href="{% url "invoices dashboard edit" id=invoice.id %}">
+                            <i class="fa-solid fa-regular fa-pencil"></i>
+                            Edit
+                        </a>
+                    </li>
+                    <li>
+                        <button hx-delete="{% url 'api:invoices:delete' %}"
                                     hx-target="closest tr"
                                     hx-confirm="Are you sure you would like to delete invoice #{{ invoice.id }}?"
                                     hx-vals='{"invoice": "{{ invoice.id }}" }'
-                            >
-                                <i class="fa-solid fa-trash"></i>
-                                Delete
-                            </button>
-                        </li>
-                    </div>
+                        >
+                            <i class="fa-solid fa-trash"></i>
+                            Delete
+                        </button>
+                    </li>
                 </ul>
             </div>
         </td>

--- a/frontend/templates/pages/invoices/edit/edit.html
+++ b/frontend/templates/pages/invoices/edit/edit.html
@@ -64,4 +64,9 @@
     </form>
 
   
+
+<!-- still need to add SERVICE & PAYMENT INFORMATION fields for editing -->
+
+
+
 {% endblock content %}

--- a/frontend/templates/pages/invoices/edit/edit.html
+++ b/frontend/templates/pages/invoices/edit/edit.html
@@ -1,0 +1,67 @@
+{% extends 'base/base.html' %}
+{% load static %}
+{% load markdownify %}
+{% block content %}
+    {% include 'components/modal.html' with modals=modal_data %}
+    <form method="post" class="card bg-base-100 p-6 group">
+        {% csrf_token %}
+        <div class="divider">STEP 1 - DESTINATIONS</div>
+        <div class="my-4 flex w-full flex-col">
+            <div class="mb-2 grid grid-cols-2">
+                <h3 class="text-sm text-natural font-semibold ms-3">From</h3>
+                <h3 class="text-sm text-natural font-semibold hidden lg:block text-end me-6">To</h3>
+            </div>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 w-full" id="to_and_from_container">
+                {% include 'pages/invoices/create/edit_from_destination.html' %}
+                {% include 'pages/invoices/create/edit_to_destination.html' %}
+            </div>
+        </div>
+        <div class="divider my-4">STEP 2 - DATES</div>
+        <div class="my-4 flex w-full flex-col">
+            <div class="w-full gap-4 grid grid-cols-1 lg:grid-cols-2">
+                <div class="input_card">
+                    <div class="card-body">
+                        <div class="form-control w-full">
+                            <label class="label justify-start">
+                                Issue date
+                                <span class="required_star">*</span>
+                            </label>
+                            <input required id="dateIssued" name="date_issued" placeholder="" type="date"
+                                   class="peer input input-bordered input-block">
+                            <label class="label peer-[&amp;:not(:placeholder-shown):not(:focus):invalid]:block hidden ">
+                                <span class="label-text-alt text-error">Please enter a valid date.</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="input_card">
+                    <div class="card-body">
+                        <div class="form-control w-full">
+                            <label class="label justify-start">
+                                Due date
+                                <span class="required_star">*</span>
+                            </label>
+                            <input required name="date_due" id="dueDate" placeholder="" type="date"
+                                   class="peer input-bordered input input-block">
+                            <label class="label peer-[&amp;:not(:placeholder-shown):not(:focus):invalid]:block hidden ">
+                                <span class="label-text-alt text-error">Please enter a valid date.</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+     
+
+
+        <div class="group-invalid:tooltip" data-tip="Fill out all required details to save the invoice.">
+            <button class="btn btn-primary group-invalid:btn-disabled btn-block">
+                Update Invoice
+            </button>
+        </div>
+
+ 
+    </form>
+
+  
+{% endblock content %}

--- a/frontend/templates/pages/invoices/edit/edit.html
+++ b/frontend/templates/pages/invoices/edit/edit.html
@@ -12,8 +12,8 @@
                 <h3 class="text-sm text-natural font-semibold hidden lg:block text-end me-6">To</h3>
             </div>
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 w-full" id="to_and_from_container">
-                {% include 'pages/invoices/create/edit_from_destination.html' %}
-                {% include 'pages/invoices/create/edit_to_destination.html' %}
+                {% include 'pages/invoices/edit/edit_from_destination.html' %}
+                {% include 'pages/invoices/edit/edit_to_destination.html' %}
             </div>
         </div>
         <div class="divider my-4">STEP 2 - DATES</div>

--- a/frontend/templates/pages/invoices/edit/edit_from_destination.html
+++ b/frontend/templates/pages/invoices/edit/edit_from_destination.html
@@ -5,6 +5,9 @@
        hx-get="{% url "api:base:modal retrieve" modal_name="invoices_from_destination" %}">
     {% endif %}
 
+<!-- *Need to replace the default values with attributes from data_to_populate dict* -->
+
+
 <!-- PRE-POPULATE FIELDS WITH EXISTING DATA OF THE INVOICE-->
     <div class="card-body">
         <p class="text-md">{{ name | default:"John Smith" }}</p>
@@ -14,7 +17,7 @@
         <p class="text-sm">{{ county | default:"Oxfordshire" }}</p>
         <p class="text-sm">{{ country | default:"England" }}</p>
     </div>
-
+    
 <!-- REPLACE DEFAULT VALUES WITH WHATEVER IS ALREADY STORED FOR THE INVOICE - if user does not change field, keep whats there-->
     <input type="hidden" name="from_name" value="{{ name | default:"John Smith" }}">
     <input type="hidden" name="from_company" value="{{ company | default:"Google" }}">

--- a/frontend/templates/pages/invoices/edit/edit_from_destination.html
+++ b/frontend/templates/pages/invoices/edit/edit_from_destination.html
@@ -1,0 +1,23 @@
+{% if not swapping %}
+<button onclick="modal_invoices_from_destination.showModal();" id="from_destination"
+        class="input_card text-left"
+       hx-trigger="click once" hx-swap="beforeend" hx-target="#modal_container"
+       hx-get="{% url "api:base:modal retrieve" modal_name="invoices_from_destination" %}">
+    {% endif %}
+    <div class="card-body">
+        <p class="text-md">{{ name | default:"John Smith" }}</p>
+        <p class="text-sm">{{ company | default:"Google" }}</p>
+        <p class="text-sm">{{ address | default:"128 Example Road" }}</p>
+        <p class="text-sm">{{ city | default:"Oxford" }}</p>
+        <p class="text-sm">{{ county | default:"Oxfordshire" }}</p>
+        <p class="text-sm">{{ country | default:"England" }}</p>
+    </div>
+    <input type="hidden" name="from_name" value="{{ name | default:"John Smith" }}">
+    <input type="hidden" name="from_company" value="{{ company | default:"Google" }}">
+    <input type="hidden" name="from_address" value="{{ address | default:"128 Example Road" }}">
+    <input type="hidden" name="from_city" value="{{ city | default:"Oxford" }}">
+    <input type="hidden" name="from_county" value="{{ county | default:"Oxfordshire" }}">
+    <input type="hidden" name="from_country" value="{{ country | default:"England" }}">
+{% if not swapping %}
+</button>
+{% endif %}

--- a/frontend/templates/pages/invoices/edit/edit_from_destination.html
+++ b/frontend/templates/pages/invoices/edit/edit_from_destination.html
@@ -4,6 +4,8 @@
        hx-trigger="click once" hx-swap="beforeend" hx-target="#modal_container"
        hx-get="{% url "api:base:modal retrieve" modal_name="invoices_from_destination" %}">
     {% endif %}
+
+<!-- PRE-POPULATE FIELDS WITH EXISTING DATA OF THE INVOICE-->
     <div class="card-body">
         <p class="text-md">{{ name | default:"John Smith" }}</p>
         <p class="text-sm">{{ company | default:"Google" }}</p>
@@ -12,6 +14,8 @@
         <p class="text-sm">{{ county | default:"Oxfordshire" }}</p>
         <p class="text-sm">{{ country | default:"England" }}</p>
     </div>
+
+<!-- REPLACE DEFAULT VALUES WITH WHATEVER IS ALREADY STORED FOR THE INVOICE - if user does not change field, keep whats there-->
     <input type="hidden" name="from_name" value="{{ name | default:"John Smith" }}">
     <input type="hidden" name="from_company" value="{{ company | default:"Google" }}">
     <input type="hidden" name="from_address" value="{{ address | default:"128 Example Road" }}">

--- a/frontend/templates/pages/invoices/edit/edit_to_destination.html
+++ b/frontend/templates/pages/invoices/edit/edit_to_destination.html
@@ -1,0 +1,24 @@
+{% if not swapping %}
+    <h3 class="text-sm text-natural font-semibold block lg:hidden ms-3">To</h3>
+    <button onclick="modal_invoices_to_destination.showModal();" id="to_destination"
+            class="input_card text-left"
+            hx-trigger="click once" hx-swap="beforeend" hx-target="#modal_container"
+            hx-get="{% url "api:base:modal retrieve" modal_name="invoices_to_destination" %}">
+{% endif %}
+<div class="card-body">
+    <p class="text-md">{{ name | default:"John Smith" }}</p>
+    <p class="text-sm">{{ company | default:"Google" }}</p>
+    <p class="text-sm">{{ address | default:"128 Example Road" }}</p>
+    <p class="text-sm">{{ city | default:"Oxford" }}</p>
+    <p class="text-sm">{{ county | default:"Oxfordshire" }}</p>
+    <p class="text-sm">{{ country | default:"England" }}</p>
+</div>
+<input type="hidden" name="to_name" value="{{ name | default:"John Smith" }}">
+<input type="hidden" name="to_company" value="{{ company | default:"Google" }}">
+<input type="hidden" name="to_address" value="{{ address | default:"128 Example Road" }}">
+<input type="hidden" name="to_city" value="{{ city | default:"Oxford" }}">
+<input type="hidden" name="to_county" value="{{ county | default:"Oxfordshire" }}">
+<input type="hidden" name="to_country" value="{{ country | default:"England" }}">
+{% if not swapping %}
+    </button>
+{% endif %}

--- a/frontend/templates/pages/invoices/edit/edit_to_destination.html
+++ b/frontend/templates/pages/invoices/edit/edit_to_destination.html
@@ -5,6 +5,8 @@
             hx-trigger="click once" hx-swap="beforeend" hx-target="#modal_container"
             hx-get="{% url "api:base:modal retrieve" modal_name="invoices_to_destination" %}">
 {% endif %}
+
+<!-- PRE-POPULATE FIELDS WITH EXISTING DATA OF THE INVOICE-->
 <div class="card-body">
     <p class="text-md">{{ name | default:"John Smith" }}</p>
     <p class="text-sm">{{ company | default:"Google" }}</p>
@@ -13,6 +15,8 @@
     <p class="text-sm">{{ county | default:"Oxfordshire" }}</p>
     <p class="text-sm">{{ country | default:"England" }}</p>
 </div>
+
+<!-- REPLACE DEFAULT VALUES WITH WHATEVER IS ALREADY STORED FOR THE INVOICE - if user does not change field, keep whats there-->
 <input type="hidden" name="to_name" value="{{ name | default:"John Smith" }}">
 <input type="hidden" name="to_company" value="{{ company | default:"Google" }}">
 <input type="hidden" name="to_address" value="{{ address | default:"128 Example Road" }}">


### PR DESCRIPTION
---
title: Adding invoice editing functionality to MyFinances 
---

# Checklist

- [x] Ran the [Black Formatter]() on any new code (checks will fail without)
- [  x ] Made any changes or additions to the documentation where required
- [x] Changes generate no new warnings/errors
- [x] New and existing unit tests pass locally with my changes


## What type of PR is this?
- ✨ Feature


## Description

Incentive:

- Before implementing this feature, the invoice dashboard had 3 working actions for users to manage the invoices that they create. We noticed that a user was not yet able to edit an invoice due to the Edit feature being greyed out and incomplete. We took this opportunity to work on this functionality as we felt that this was an important component to have and a good place to start.

What has been done :heavy_check_mark: :
- [x] An edit.html page that allows the user to edit existing invoices with changes to fields like self and client information (such as name, company, addresses, ...etc) as well as issue/due dates. The page layout is consistent with that of the create invoice page and contains sub-html pages: edit_to_destination and edit_from_destination. 

- [x] Updated urls.py, _fetch_body.html which stores the path and urlpatterns to invoice actions. Created edit.py with a decorator, view function, and associated methods for updating invoice attributes. 

![invoice_edit](https://github.com/TreyWW/MyFinances/assets/48864969/a6fa8ba1-39d5-4c3f-9a26-2ca7998eac97)
![update_invoice](https://github.com/TreyWW/MyFinances/assets/48864969/b5b65400-9731-44d9-82a8-a3a9a0af08d7)
We tested this in the backend and saw changes take place in the database which reflects the modifications by the user on updating their invoice information.

- [x] Once editing is complete, the user will be brought back to the invoice dashboard where changes to the due date of invoices will be re-evaluated and payment status will be updated accordingly.


SCREENSHOT showcase:
![demoedit](https://github.com/TreyWW/MyFinances/assets/48864969/dc24ba93-5a12-4985-9d71-3af36eaceb0b)
![demoedit2](https://github.com/TreyWW/MyFinances/assets/48864969/fe49b08f-979c-4e48-b3f7-87349a60750b)

After changing the fields above and extending the due date of the invoice by a year, we get the following:

![demoedit3](https://github.com/TreyWW/MyFinances/assets/48864969/109d7c04-e2b5-4493-ab8e-69ad213881a9)
![demoedit4](https://github.com/TreyWW/MyFinances/assets/48864969/51eddf83-08bd-425e-bfe2-03b8e1427346)


IDEAS and things to be done:

- [x] We initially wanted to pre-populate the fields of the edit invoice page with stored data of the existing invoice that the user wishes to modify. Due to time constraints, this still needs to be done. I have made a method to store the attributes of invoice objects in dicts based on invoice id. This can then be passed within the render template parameters to the front end. 
- [x] The default values of fields in edit_to_destination.html and edit_from_destination.html will need to be replaced with values from the dict or json (whichever works here)
- [x] We noticed a bug with inputting/modifying fields like company and county where changes sometimes do not appear visually in the boxes after a save. This seems to be an existing issue that happens to the create invoice feature as well
- [x] A user-friendly suggestion would be to allow all fields of edit invoice to be optional. User is NOT required to change anything and they should be able to "update invoice" from edit invoice page without actually modifying anything.


## Added/updated tests?
- 🙅 no, because they aren't needed



## Related PRs, Issues etc
- N/A
