### PR TITLE
Removed options for postgres

### DIFF
--- a/settings/local_settings.py
+++ b/settings/local_settings.py
@@ -30,7 +30,7 @@ if DB_TYPE == "mysql" or DB_TYPE == "postgres":
             or (3306 if DB_TYPE == "mysql" else 5432),
             "OPTIONS": {
                 "sql_mode": "traditional",
-            },
+            } if DB_TYPE == "mysql" else {},
         }
     }
 


### PR DESCRIPTION
Options caused `invalid connection option "sql_mode"`, now fixed