### PR TITLE
Additional test case

### DIFF
--- a/tests/views/test_receipts.py
+++ b/tests/views/test_receipts.py
@@ -1,10 +1,8 @@
-import uuid
-
 from django.contrib.messages import get_messages
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse, resolve
 
-from backend.models import Receipt, ReceiptDownloadToken
+from backend.models import Receipt
 from tests.handler import ViewTestCase
 
 
@@ -84,45 +82,3 @@ class ReceiptsAPITestCase(ViewTestCase):
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), "No image found")
-
-
-class ReceiptDownloadEndpointsTest(ViewTestCase):
-    def setUp(self):
-        super().setUp()
-        self.receipt = Receipt.objects.create(
-            user=self.log_in_user, image=SimpleUploadedFile("mock_image.jpg", b"image_content", "image/jpeg")
-        )
-        self.token = ReceiptDownloadToken.objects.create(user=self.log_in_user, file=self.receipt)
-        self.download_receipt_url = reverse("api:receipts:download_receipt", args=[self.token.token])
-        self.generate_download_link_url = reverse("api:receipts:generate_download_link", args=[self.receipt.id])
-
-    def test_download_receipt_valid_token(self):
-        self.login_user()
-        response = self.client.get(self.download_receipt_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "image/jpeg")
-
-    def test_download_receipt_invalid_token(self):
-        self.login_user()
-        invalid_token = uuid.uuid4()  # Generate a valid UUID
-        invalid_url = reverse("api:receipts:download_receipt", args=[invalid_token])
-        response = self.client.get(invalid_url)
-        self.assertEqual(response.status_code, 404)  # Update expected status code
-
-    def test_download_receipt_used_token(self):
-        self.login_user()
-        self.client.get(self.download_receipt_url)  # Use the token once
-        response = self.client.get(self.download_receipt_url)  # Try to use the token again
-        self.assertEqual(response.status_code, 404)  # Expect a 404 response
-
-    def test_generate_download_link_valid_receipt(self):
-        self.login_user()
-        response = self.client.get(self.generate_download_link_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response["Content-Type"], "application/json")
-
-    def test_generate_download_link_invalid_receipt(self):
-        self.login_user()
-        invalid_url = reverse("api:receipts:generate_download_link", args=[9999])  # Assuming 9999 is an invalid receipt id
-        response = self.client.get(invalid_url)
-        self.assertEqual(response.status_code, 404)

--- a/tests/views/test_reciepts_download.py
+++ b/tests/views/test_reciepts_download.py
@@ -21,7 +21,6 @@ class ReceiptDownloadEndpointsTest(TestCase):
                 '"ReceiptDownloadEndpointsTest" tearDownClass() failed due to random PermissionError '
                 "(only on Windows). Files in /media/receipts have not been deleted. Run tests again to delete files."
             )
-            pass
         super().tearDownClass()
 
     def setUp(self):

--- a/tests/views/test_reciepts_download.py
+++ b/tests/views/test_reciepts_download.py
@@ -1,0 +1,65 @@
+import os
+import shutil
+import uuid
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from django.test import TestCase
+
+from backend.models import Receipt, ReceiptDownloadToken, User
+
+
+class ReceiptDownloadEndpointsTest(TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        directory = "media/receipts"
+        try:
+            shutil.rmtree(directory)
+            os.mkdir(directory)
+        except PermissionError:
+            print(
+                '"ReceiptDownloadEndpointsTest" tearDownClass() failed due to random PermissionError '
+                "(only on Windows). Files in /media/receipts have not been deleted. Run tests again to delete files."
+            )
+            pass
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.log_in_user = User.objects.create_user(username="test@example.com", password="user", email="test@example.com")
+        self.client.login(username="test@example.com", password="user")
+
+        self.receipt = Receipt.objects.create(
+            user=self.log_in_user, image=SimpleUploadedFile("mock_image.jpg", b"image_content", "image/jpeg")
+        )
+        self.token = ReceiptDownloadToken.objects.create(user=self.log_in_user, file=self.receipt)
+        self.download_receipt_url = reverse("api:receipts:download_receipt", args=[self.token.token])
+        self.generate_download_link_url = reverse("api:receipts:generate_download_link", args=[self.receipt.id])
+
+    def test_download_receipt_valid_token(self):
+        response = self.client.get(self.download_receipt_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "image/jpeg")
+
+    def test_download_receipt_invalid_token(self):
+        invalid_token = uuid.uuid4()  # Generate a valid UUID
+        invalid_url = reverse("api:receipts:download_receipt", args=[invalid_token])
+        response = self.client.get(invalid_url)
+        self.assertEqual(response.status_code, 404)  # Update expected status code
+
+    def test_download_receipt_used_token(self):
+        self.client.get(self.download_receipt_url)  # Use the token once
+        response = self.client.get(self.download_receipt_url)  # Try to use the token again
+        self.assertEqual(response.status_code, 404)  # Expect a 404 response
+
+    def test_generate_download_link_valid_receipt(self):
+        response = self.client.get(self.generate_download_link_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.client.logout()
+
+    def test_generate_download_link_invalid_receipt(self):
+        invalid_url = reverse("api:receipts:generate_download_link", args=[9999])  # Assuming 9999 is an invalid receipt id
+        response = self.client.get(invalid_url)
+        self.assertEqual(response.status_code, 404)
+        self.client.logout()

--- a/tests/views/test_reciepts_download.py
+++ b/tests/views/test_reciepts_download.py
@@ -62,3 +62,13 @@ class ReceiptDownloadEndpointsTest(TestCase):
         response = self.client.get(invalid_url)
         self.assertEqual(response.status_code, 404)
         self.client.logout()
+
+    def test_download_receipt_user_mismatch(self):
+        another_user = User.objects.create_user(username="user@example.com", password="anotherpassword", email="user@example.com")
+        another_token = ReceiptDownloadToken.objects.create(user=another_user, file=self.receipt)
+        self.client.login(username="user@example.com", password="user")
+
+        download_receipt_url = reverse("api:receipts:download_receipt", args=[another_token.token])
+        response = self.client.get(download_receipt_url)
+        self.assertEquals(response.status_code, 403)
+        self.assertEquals(response.content, b"Forbidden")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
To increase test coverage I've added a `test_download_receipt_user_mismatch` test case to check if the status and content of response is correct when user mismatch occur. 

It covers
```py
if download_token.user != request.user:
    return HttpResponse("Forbidden", status=403)  # 403 Forbidden
```
from **download.py** in */backend/api/receipts/* folder.


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- ✨ Feature

<!-- (optionally add your own bullet points) -->

## Added/updated tests?
<!-- delete all that don't apply -->
- 👍 yes


## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
