### PR TITLE
Added user mismatch test case

### DIFF
--- a/tests/views/test_reciepts_download.py
+++ b/tests/views/test_reciepts_download.py
@@ -70,5 +70,5 @@ class ReceiptDownloadEndpointsTest(TestCase):
 
         download_receipt_url = reverse("api:receipts:download_receipt", args=[another_token.token])
         response = self.client.get(download_receipt_url)
-        self.assertEquals(response.status_code, 403)
-        self.assertEquals(response.content, b"Forbidden")
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.content, b"Forbidden")

--- a/tests/views/test_reciepts_download.py
+++ b/tests/views/test_reciepts_download.py
@@ -62,3 +62,13 @@ class ReceiptDownloadEndpointsTest(TestCase):
         response = self.client.get(invalid_url)
         self.assertEqual(response.status_code, 404)
         self.client.logout()
+
+    def test_download_receipt_user_mismatch(self):
+        another_user = User.objects.create_user(username="user@example.com", password="anotherpassword", email="user@example.com")
+        another_token = ReceiptDownloadToken.objects.create(user=another_user, file=self.receipt)
+        self.client.login(username="user@example.com", password="user")
+
+        download_receipt_url = reverse("api:receipts:download_receipt", args=[another_token.token])
+        response = self.client.get(download_receipt_url)
+        self.assertEquals(response.status_code, 403)
+        self.assertEquals(response.content, b"Forbidden")


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

To increase test coverage I've added a `test_download_receipt_user_mismatch` test case to check if the status and content of response is correct when user mismatch occur.

It covers
```py
if download_token.user != request.user:
    return HttpResponse("Forbidden", status=403)  # 403 Forbidden
```
from **download.py** in */backend/api/receipts/* folder.


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- ✨ Feature

<!-- (optionally add your own bullet points) -->

## Added/updated tests?
<!-- delete all that don't apply -->
- 👍 yes


## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
