### PR TITLE
fix validate_request return type

### DIFF
--- a/backend/api/quotas/requests.py
+++ b/backend/api/quotas/requests.py
@@ -62,7 +62,7 @@ def error(request: HttpRequest, message: str) -> HttpResponse:
     return render(request, "partials/messages_list.html")
 
 
-def validate_request(new_value, reason, current) -> Union[True, Error]:
+def validate_request(new_value, reason, current) -> Union[bool, Error]:
     if not new_value:
         return Error("Please enter a valid increase value")
 


### PR DESCRIPTION
## Description
One little fix related to the return type of validate_request function. It's returning Union[bool, Error] instead Union[True, Error] which was rising an error 


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 🐛 Bug Fix

<!-- (optionally add your own bullet points) -->

## Added/updated tests?
<!-- delete all that don't apply -->
- 🙋 no, because **I need help**


## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
