### PR TITLE
[282] Fixed invoice bar overlap for smaller screens

### DIFF
--- a/frontend/templates/pages/invoices/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/view/invoice_page.html
@@ -6,15 +6,15 @@
             <div tabindex="-1"
                  id="status_banner"
                  class="print-ignore fixed top-0 left-0 z-50 grid grid-cols-3 w-full p-4 bg-base-100 shadow text-base-content">
-                <div>
+                <div class="return-btn">
                     {% if type == "preview" %}
                         <a href="{% url 'invoices:dashboard' %}" class="btn btn-sm btn-outline">
                             <i class="fa-solid fa-arrow-left me-2"></i>
-                            Go Back
+                            <p class="return-btn-text">Go Back</p>
                         </a>
                     {% endif %}
                 </div>
-                <div class="flex items-center mx-auto">
+                <div class="flex items-center mx-auto status-btn">
                     <p class="flex items-center text-sm font-normal">
                         {% with ps=invoice.payment_status %}
                             {% if ps == "paid" %}
@@ -42,16 +42,16 @@
                         </p>
                     {% endwith %}
                 </div>
-                <div class="flex justify-end float-right">
+                <div class="flex justify-end float-right options-btn">
                     <a class="btn btn-sm gradient-btn me-2" href="" download>
                         <i class="fa-solid fa-download me-2"></i>
-                        Download
+                        <p class="options-text">Download</p>
                     </a>
                     <button onclick="window.print()" class="btn btn-sm gradient-btn me-2">
                         <i class="fa-solid fa-print me-2"></i>
-                        Print
+                        <p class="options-text">Print</p>
                     </button>
-                    <a class="btn btn-sm gradient-btn me-8"
+                    <a class="btn btn-sm gradient-btn me-8 share-btn"
                        href="{% url "invoices:manage_access" invoice_id=invoice.id %}">Share Invoice</a>
                     <div class="flex items-center">
                         <button onclick="document.getElementById('status_banner').remove();"
@@ -84,6 +84,55 @@
     .gradient-btn:hover {
         background: linear-gradient(45deg, #6874fc, #80e1ff);
     }
+    @media (max-width: 375px) {
+        .return-btn {
+            .fa-arrow-left {
+                margin-inline-end: 0rem;
+            }
+            .return-btn-text {
+                display: none;
+            }
+        }
+    }
+
+    @media (max-width: 768px) {
+        #status_banner {
+            display: flex;
+            flex-direction: column;
+
+            .options-btn {
+                order: 2;
+                margin-top: -2rem;
+
+                    .options-text {
+                        display: none;
+                    }
+
+                    .fa-download,
+                    .fa-print {
+                        margin-inline-end: 0;
+                    }
+
+                    .share-btn {
+                        margin-inline-end: 1rem;
+                    }
+            }
+
+            .status-btn {
+                flex-direction: row;
+                flex-grow: 1;
+                order: 5;
+                align-self: center;
+                margin-top: 0.5rem;
+            }
+
+            .return-btn {
+                display: flex;
+                width: fit-content;
+                order: 1;
+            }
+        }
+      }
 
     @media print {
 


### PR DESCRIPTION
## Description

Added breakpoints with css changes in order to better rescale and align the invoice bar elements for smaller devices.
New changes below:
XS:
<img width="506" alt="image" src="https://github.com/TreyWW/MyFinances/assets/58274307/307599cb-10d9-4250-acb7-695b0be9601c">

SM:
<img width="661" alt="image" src="https://github.com/TreyWW/MyFinances/assets/58274307/6bb1c9f1-9ad6-463e-a547-f277cccddf96">

MD:
<img width="861" alt="image" src="https://github.com/TreyWW/MyFinances/assets/58274307/53ee8637-710b-4a42-a5e8-50317277ce44">

While LG remains untouched:
<img width="979" alt="image" src="https://github.com/TreyWW/MyFinances/assets/58274307/38f213ce-fdc9-4150-8b37-d108015b4902">

# Checklist

- [X] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [X] Made any changes or additions to the documentation _where required_ (not needed)
- [X] Changes generate no new warnings/errors
- [X] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 🐛 Bug Fix

## Added/updated tests?
- 🙅 no, because they aren't needed

## Related PRs, Issues etc
- Related Issue #282
- Closes #282  <!-- This automatically closes the issue upon merge -->
