### PR TITLE
309: Price in the invoice is missing currency symbol

### DIFF
--- a/frontend/templates/pages/invoices/view/invoice.html
+++ b/frontend/templates/pages/invoices/view/invoice.html
@@ -72,7 +72,7 @@
                             <span class="text-sm text-gray-900">{{ item.hours }}</span>
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap">
-                            <span class="text-sm text-gray-900">{{ item.price_per_hour }}</span>
+                            <span class="text-sm text-gray-900">{{ invoice.get_currency_symbol }}{{ item.price_per_hour }}</span>
                         </td>
                         <td class="px-6 py-4 text-right whitespace-nowrap">
                             <span class="text-sm text-gray-900">{{ invoice.get_currency_symbol }}{{ item.get_total_price | floatformat:2 }}</span>


### PR DESCRIPTION
## Description
- added currency symbol to the price in the invoice

# Checklist
- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- 🐛 Bug Fix

## Added/updated tests?
- 🙅 no, because they aren't needed

## Related PRs, Issues etc
- Closes #309 
