### PR TITLE
Server Startup failure due to Unused Schedule Configuration variable

### DIFF
--- a/infrastructure/aws/iam/sfn.py
+++ b/infrastructure/aws/iam/sfn.py
@@ -1,14 +1,9 @@
 import json
-from typing import NoReturn
-
+import logging
 from mypy_boto3_iam.type_defs import CreatePolicyResponseTypeDef, PolicyTypeDef
-
-from infrastructure.aws.handler import get_iam_client, DEBUG_LEVEL
+from infrastructure.aws.handler import get_iam_client as iam_client, DEBUG_LEVEL
 from settings.settings import AWS_TAGS_APP_NAME
 
-iam_client = get_iam_client()
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -21,8 +16,8 @@ def get_sfn_execute_role_arn() -> str | None:
         print("[AWS] Fetching scheduler role by name...", flush=True)
 
     try:
-        response = iam_client.get_role(RoleName=f"{AWS_TAGS_APP_NAME}-invoicing-scheduler")
-    except (iam_client.exceptions.NoSuchEntityException, iam_client.exceptions.ServiceFailureException):
+        response = iam_client().get_role(RoleName=f"{AWS_TAGS_APP_NAME}-invoicing-scheduler")
+    except (iam_client().exceptions.NoSuchEntityException, iam_client().exceptions.ServiceFailureException):
         response = {}
 
     if response.get("Role"):
@@ -38,7 +33,7 @@ def get_or_create_policy() -> CreatePolicyResponseTypeDef | PolicyTypeDef:
     if DEBUG_LEVEL == "debug":
         print("[AWS] Fetching all policies by prefix...", flush=True)
 
-    response = iam_client.list_policies(Scope="Local", PathPrefix=f"/{AWS_TAGS_APP_NAME}-scheduled-invoices/")
+    response = iam_client().list_policies(Scope="Local", PathPrefix=f"/{AWS_TAGS_APP_NAME}-scheduled-invoices/")
 
     policies = [
         policy for policy in response.get("Policies", []) if policy.get("PolicyName") == f"{AWS_TAGS_APP_NAME}-invoicing-scheduler-fn"
@@ -57,7 +52,7 @@ def get_or_create_policy() -> CreatePolicyResponseTypeDef | PolicyTypeDef:
     if DEBUG_LEVEL:
         print("[AWS] Creating new policy for scheduler step function to access API Destination...", flush=True)
 
-    return iam_client.create_policy(
+    return iam_client().create_policy(
         PolicyName=f"{AWS_TAGS_APP_NAME}-invoicing-scheduler-fn",
         Path=f"/{AWS_TAGS_APP_NAME}-scheduled-invoices/",
         PolicyDocument=json.dumps(

--- a/infrastructure/aws/schedules/list_schedules.py
+++ b/infrastructure/aws/schedules/list_schedules.py
@@ -3,10 +3,8 @@ from typing import List
 
 from mypy_boto3_scheduler.type_defs import ScheduleSummaryTypeDef
 
-from infrastructure.aws.handler import get_event_bridge_scheduler
+from infrastructure.aws.handler import get_event_bridge_scheduler as event_bridge_scheduler
 from settings.settings import AWS_TAGS_APP_NAME
-
-event_bridge_scheduler = get_event_bridge_scheduler()
 
 
 @dataclass(frozen=True)
@@ -24,7 +22,7 @@ ScheduleListResponse = ErrorResponse | SuccessResponse
 
 def list_schedules() -> ScheduleListResponse:
     try:
-        schedules = event_bridge_scheduler.list_schedules(
+        schedules = event_bridge_scheduler().list_schedules(
             NamePrefix=f"{AWS_TAGS_APP_NAME}-scheduled-invoices",
             State="ENABLED",
         )  # possibly add groups in the future


### PR DESCRIPTION
Issue - Error During Server Startup Due to Unused Schedule Configuration

Changes Made:

Refactored the code to initialize iam_client within functions where it is needed, instead of initializing it globally. Implemented lazy initialization logic to ensure that iam_client is initialized only when it is accessed for the first time. Verified that the changes resolve the server startup error and do not introduce any new issues.

## Description

I encountered an issue where the initialization of iam_client  and event_bridge_scheduler was causing an error during server startup. To address this issue, I have modified the code to lazily initialize iam_client and event_bridge_scheduler only when it is needed. This prevents the error from occurring during server startup.


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 🐛 Bug Fix

## Added/updated tests?
- 🙅 no, because they aren't needed



