### PR TITLE
Receipt accepts up to two decimal points

### DIFF
--- a/frontend/templates/modals/receipts_upload.html
+++ b/frontend/templates/modals/receipts_upload.html
@@ -46,6 +46,7 @@
         </label>
         <input required
                type="number"
+               step=".01"
                name="total_price"
                class="input input-bordered">
     </div>


### PR DESCRIPTION
## Description

The receipt can now accept input of up to two decimal points(only integers were accepted prior). 

# Checklist

- [X] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [X] Made any changes or additions to the documentation _where required_
- [X] Changes generate no new warnings/errors
- [X] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
- ✨ Feature

## Added/updated tests?
- 🙅 no, because they aren't needed



## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
