### PR TITLE
Fix: Login page broken on mobile - #333

### DIFF
--- a/frontend/templates/base/auth.html
+++ b/frontend/templates/base/auth.html
@@ -5,8 +5,8 @@
         <div class="min-h-screen bg-base-200 flex items-center">
             <div class="card my-4 mx-auto w-full max-w-5xl shadow-xl">
                 <div class="grid  md:grid-cols-2 grid-cols-1  bg-base-100 rounded-xl">
-                    <div class="hero min-h-full rounded-l-xl bg-base-200">
-                        <div class="hero-content py-12">
+                    <div class="hero rounded-l-xl bg-base-200">
+                        <div class="hero-content py-12 min-h-full">
                             <div class="max-w-md">
                                 <h1 class="text-3xl text-center font-bold ">Dashboard</h1>
                                 <div class="text-center mt-12 mb-24">


### PR DESCRIPTION
## Description

Removed the "min-h-full" class from the parent div and added it to its child div to resolve an issue where the login page was broken on mobile devices. The parent div had a grid class, which caused the child div to inherit a height of 100%, leading to layout issues on mobile screens. By moving the "min-h-full" class to the child div, we ensure that the content has a height of 100% without affecting the layout. Tested on iPhone XR using both Chrome and Safari browsers.


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code (checks will fail without)
- [ ] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [ ] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my changes


## What type of PR is this?
- 🐛 Bug Fix


## Added/updated tests?
- 🙅 no, because they aren't needed


## Related PRs, Issues, etc
- Related Issue #333
- Closes #333
