### PR TITLE
fixed top banner for invoice preview for users that are not logged in

### DIFF
--- a/frontend/templates/pages/invoices/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/view/invoice_page.html
@@ -42,7 +42,6 @@
                         </p>
                     {% endwith %}
                 </div>
-
                 <div class="flex justify-end float-right options-btn">
                     <a class="btn btn-sm gradient-btn me-2" href="" download>
                         <i class="fa-solid fa-download me-2"></i>
@@ -53,8 +52,8 @@
                         <p class="options-text">Print</p>
                     </button>
                     {% if request.user.is_authenticated %}
-                    <a class="btn btn-sm gradient-btn me-8 share-btn"
-                       href="{% url "invoices:manage_access" invoice_id=invoice.id %}">Share Invoice</a>
+                        <a class="btn btn-sm gradient-btn me-8 share-btn"
+                           href="{% url "invoices:manage_access" invoice_id=invoice.id %}">Share Invoice</a>
                     {% endif %}
                     <div class="flex items-center">
                         <button onclick="document.getElementById('status_banner').remove();"

--- a/frontend/templates/pages/invoices/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/view/invoice_page.html
@@ -3,7 +3,6 @@
     {% include 'base/_head.html' %}
     <body style="background-color: #94c0eb;">
         <div class="flex-1 min-h-screen overflow-y-auto px-7 pb-4 bg-base-200 invoice-page">
-            {% if request.user.is_authenticated %}
             <div tabindex="-1"
                  id="status_banner"
                  class="print-ignore fixed top-0 left-0 z-50 grid grid-cols-3 w-full p-4 bg-base-100 shadow text-base-content">
@@ -53,8 +52,10 @@
                         <i class="fa-solid fa-print me-2"></i>
                         <p class="options-text">Print</p>
                     </button>
+                    {% if request.user.is_authenticated %}
                     <a class="btn btn-sm gradient-btn me-8 share-btn"
                        href="{% url "invoices:manage_access" invoice_id=invoice.id %}">Share Invoice</a>
+                    {% endif %}
                     <div class="flex items-center">
                         <button onclick="document.getElementById('status_banner').remove();"
                                 type="button"
@@ -65,7 +66,6 @@
                     </div>
                 </div>
             </div>
-            {% endif %}
             <!-- Start of Invoice -->
             {% include "pages/invoices/view/invoice.html" %}
         </div>

--- a/frontend/templates/pages/invoices/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/view/invoice_page.html
@@ -3,6 +3,7 @@
     {% include 'base/_head.html' %}
     <body style="background-color: #94c0eb;">
         <div class="flex-1 min-h-screen overflow-y-auto px-7 pb-4 bg-base-200 invoice-page">
+            {% if request.user.is_authenticated %}
             <div tabindex="-1"
                  id="status_banner"
                  class="print-ignore fixed top-0 left-0 z-50 grid grid-cols-3 w-full p-4 bg-base-100 shadow text-base-content">
@@ -42,6 +43,7 @@
                         </p>
                     {% endwith %}
                 </div>
+
                 <div class="flex justify-end float-right options-btn">
                     <a class="btn btn-sm gradient-btn me-2" href="" download>
                         <i class="fa-solid fa-download me-2"></i>
@@ -63,6 +65,7 @@
                     </div>
                 </div>
             </div>
+            {% endif %}
             <!-- Start of Invoice -->
             {% include "pages/invoices/view/invoice.html" %}
         </div>


### PR DESCRIPTION
## Description

bug: Share Invoice button shouldn't be visible when not logged in. Now it is not visible when a non-logged-in user views the invoice


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks will fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my changes


## What type of PR is this?
<!-- delete all that don't apply -->
- 🐛 Bug Fix


## Added/updated tests?
<!-- delete all that don't apply -->
- 🙅 no, because they aren't needed
- 🙋 no, because **I need help**


## Related PRs, Issues etc
- Related Issue #337
- Closes # <!-- This automatically closes the issue upon merge -->
