### PR TITLE
Fixed ValueError issue

### DIFF
--- a/backend/api/invoices/create/services/add.py
+++ b/backend/api/invoices/create/services/add.py
@@ -23,10 +23,10 @@ def add_service(request: HtmxHttpRequest):
     list_of_current_rows = [row for row in zip(list_hours, list_service_name, list_service_description, list_price_per_hour)]
 
     if not existing_service:
-        hours = int(request.POST.get("post_hours", ""))
+        hours = int(request.POST.get("post_hours", "0"))
         service_name = request.POST.get("post_service_name")
         service_description = request.POST.get("post_service_description")
-        price_per_hour = int(request.POST.get("post_rate", ""))
+        price_per_hour = int(request.POST.get("post_rate", "0"))
 
         if not hours:
             return JsonResponse(


### PR DESCRIPTION
## Description

- Changed empty strings `""` to `"0"`  because `int("")`  would cause an `ValueError`. If hours or price_per_hour field will be empty `0` will give a desired false in `if not` statements.


# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- 🐛 Bug Fix

<!-- (optionally add your own bullet points) -->

## Added/updated tests?
<!-- delete all that don't apply -->
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
