### PR TITLE
Prevent Receipt Search Page Reload

### DIFF
--- a/frontend/templates/pages/receipts/_search.html
+++ b/frontend/templates/pages/receipts/_search.html
@@ -1,4 +1,4 @@
-<form method="post">
+<form method="post" onsubmit="return false">
     {% csrf_token %}
     <input type="text"
            placeholder="Search"


### PR DESCRIPTION
## Description

Previously, pressing "Enter" keyboard key after typing a receipt search query on the receipt management dashboard caused the entire page to refresh due to default form submission behavior, leading to a confusing user experience. This PR fixes the issue by preventing the default page reload on search form submission.

## Checklist

- [X] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [X] Made any changes or additions to the documentation _where required_
- [X] Changes generate no new warnings/errors
- [X] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 🐛 Bug Fix

## Added/updated tests?
- 🙅 no, because they aren't needed

## Related PRs, Issues etc
- Closes #393 
