### PR TITLE
Fixed login button (#432)

### DIFF
--- a/frontend/templates/pages/auth/create_account_manual.html
+++ b/frontend/templates/pages/auth/create_account_manual.html
@@ -55,7 +55,7 @@
             </div>
         </div>
         <p class="text-center  text-error mt-8"></p>
-        <button type="submit" class="btn mt-2 w-full btn-primary">Login</button>
+        <button type="submit" class="btn mt-2 w-full btn-primary">Create</button>
         <div class="text-center mt-4">
             Already have an account?
             <a href="{% url 'auth:login' %}"


### PR DESCRIPTION
## Description
When creating a new account, the confirmation button used to say "Login". It has been correct to say "Create". 

# Checklist
- [x] Changes generate no new warnings/errors

## What type of PR is this?
- 🐛 Bug Fix

## Added/updated tests?
- 🙅 no, because they aren't needed
