### PR TITLE
Fix code scanning alert no. 21: URL redirection from remote source

### DIFF
--- a/backend/core/views/auth/login.py
+++ b/backend/core/views/auth/login.py
@@ -86,7 +86,7 @@ def login_manual(request: HttpRequest):
 
 def redirect_to_login(email: str, redirect_url: str):
     if not url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=None):
-        redirect_url = reverse('dashboard')
+        redirect_url = reverse("dashboard")
     return redirect(f"{reverse('auth:login')}?email={email}&next={redirect_url}")
 
 

--- a/backend/core/views/auth/login.py
+++ b/backend/core/views/auth/login.py
@@ -9,6 +9,7 @@ from django.core.validators import validate_email
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render, redirect
 from django.urls import resolve, reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.urls.exceptions import Resolver404
 from django.utils.decorators import method_decorator
 from django.views import View
@@ -84,6 +85,8 @@ def login_manual(request: HttpRequest):
 
 
 def redirect_to_login(email: str, redirect_url: str):
+    if not url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=None):
+        redirect_url = reverse('dashboard')
     return redirect(f"{reverse('auth:login')}?email={email}&next={redirect_url}")
 
 


### PR DESCRIPTION
Fixes [https://github.com/TreyWW/MyFinances/security/code-scanning/21](https://github.com/TreyWW/MyFinances/security/code-scanning/21)

To fix the problem, we need to validate the `redirect_url` to ensure it is a safe and allowed URL. We can use Django's `url_has_allowed_host_and_scheme` function to check that the URL is safe to redirect to. This function ensures that the URL does not contain an explicit host name and is within the allowed hosts.

1. Import the `url_has_allowed_host_and_scheme` function from `django.utils.http`.
2. Modify the `redirect_to_login` function to validate the `redirect_url` using `url_has_allowed_host_and_scheme`.
3. If the `redirect_url` is not valid, redirect to a default safe URL (e.g., the home page).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
