### PR TITLE
Fix code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/backend/core/api/public/endpoints/webhooks/webhook_task_queue_handler.py
+++ b/backend/core/api/public/endpoints/webhooks/webhook_task_queue_handler.py
@@ -1,5 +1,5 @@
 from rest_framework.response import Response
-
+import logging
 from backend.core.api.public import APIAuthToken
 from rest_framework.decorators import api_view
 
@@ -42,5 +42,5 @@ def webhook_task_queue_handler_view_endpoint(request):
         return Response({"status": "success", "result": result})
 
     except Exception as e:
-        print(f"Error executing webhook task: {str(e)}")
-        return Response({"status": "error", "message": str(e)}, status=500)
+        logging.error(f"Error executing webhook task: {str(e)}")
+        return Response({"status": "error", "message": "An internal error has occurred."}, status=500)


### PR DESCRIPTION
Fixes [https://github.com/TreyWW/MyFinances/security/code-scanning/22](https://github.com/TreyWW/MyFinances/security/code-scanning/22)

To fix the problem, we need to ensure that detailed error messages are not exposed to the end user. Instead, we should log the detailed error message on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the error and return a generic message.

**Steps to fix:**
1. Import the `logging` module to enable logging of error messages.
2. Replace the line that returns the detailed error message with a line that logs the error and returns a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
