### PR TITLE
Bug - Change to API Response 

### DIFF
--- a/backend/core/api/public/decorators.py
+++ b/backend/core/api/public/decorators.py
@@ -2,7 +2,6 @@ from functools import wraps
 
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
-from rest_framework.response import Response
 from rest_framework import status
 
 from backend.models import TeamMemberPermission, Organization, Client

--- a/backend/core/api/public/decorators.py
+++ b/backend/core/api/public/decorators.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from backend.models import TeamMemberPermission, Organization, Client
+from backend.core.api.public.helpers.response import APIResponse
 
 import logging
 
@@ -21,21 +22,21 @@ def require_scopes(scopes):
                 logger.info(
                     f"Authentication credentials were not provided in api request |" f" {request.META.get('REMOTE_ADDR', 'Unknown IP')}"
                 )
-                return Response({"detail": "Authentication credentials were not provided."}, status=status.HTTP_401_UNAUTHORIZED)
+                return APIResponse(False, {"detail": "Authentication credentials were not provided."}, status=status.HTTP_401_UNAUTHORIZED)
 
             if request.team_id and not request.team:
-                return Response({"detail": "Team not found."}, status=status.HTTP_404_NOT_FOUND)
+                return APIResponse(False, {"detail": "Team not found."}, status=status.HTTP_404_NOT_FOUND)
 
             if request.team:
                 # Check for team permissions based on team_id and scopes
                 if not request.team.is_owner(token.user) and not request.team.is_logged_in_as_team(request):
                     team_permissions = TeamMemberPermission.objects.filter(team=request.team, user=token.user).first()
                     if not team_permissions or not all(scope in team_permissions.scopes for scope in scopes):
-                        return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+                        return APIResponse(False, {"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
 
             # Check for global API Key permissions based on token scopes
             if not all(scope in token.scopes for scope in scopes):
-                return Response({"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
+                return APIResponse(False, {"detail": "Permission denied."}, status=status.HTTP_403_FORBIDDEN)
 
             token.update_last_used()
 

--- a/backend/core/api/public/endpoints/Invoices/delete.py
+++ b/backend/core/api/public/endpoints/Invoices/delete.py
@@ -26,4 +26,4 @@ def delete_invoice_endpoint(request: APIRequest):
 
     invoice.delete()
 
-    return APIResponse(False, {"message": "Invoice successfully deleted"}, status=status.HTTP_200_OK)
+    return APIResponse(True, {"message": "Invoice successfully deleted"}, status=status.HTTP_200_OK)

--- a/backend/core/api/public/endpoints/Invoices/delete.py
+++ b/backend/core/api/public/endpoints/Invoices/delete.py
@@ -1,10 +1,11 @@
 from django.http import QueryDict
 from rest_framework import status
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.types import APIRequest
+from backend.core.api.public.helpers.response import APIResponse
+
 from backend.models import Invoice, QuotaLimit
 
 
@@ -16,13 +17,13 @@ def delete_invoice_endpoint(request: APIRequest):
     try:
         invoice = Invoice.objects.get(id=delete_items.get("invoice", ""))
     except Invoice.DoesNotExist:
-        return Response({"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
+        return APIResponse(False, {"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
 
     if not invoice.has_access(request.user):
-        return Response({"error": "You do not have permission to delete this invoice"}, status=status.HTTP_403_FORBIDDEN)
+        return APIResponse(False, {"error": "You do not have permission to delete this invoice"}, status=status.HTTP_403_FORBIDDEN)
 
     QuotaLimit.delete_quota_usage("invoices-count", request.user, invoice.id, invoice.date_created)
 
     invoice.delete()
 
-    return Response({"message": "Invoice successfully deleted"}, status=status.HTTP_200_OK)
+    return APIResponse(False, {"message": "Invoice successfully deleted"}, status=status.HTTP_200_OK)

--- a/backend/core/api/public/endpoints/Invoices/download_pdf.py
+++ b/backend/core/api/public/endpoints/Invoices/download_pdf.py
@@ -5,6 +5,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.helpers.deprecate import deprecated
@@ -61,7 +62,7 @@ from backend.core.api.public.helpers.response import APIResponse
 @api_view(["GET"])
 @deprecated(datetime(2024, 7, 16), datetime(2024, 7, 16))
 @require_scopes(["invoices:read"])
-def download(request: APIRequest, id: str) -> HttpResponse | APIResponse:
+def download(request: APIRequest, id: str) -> HttpResponse | Response:
     try:
         if request.team:
             invoice = Invoice.objects.get(organization=request.team, id=id)

--- a/backend/core/api/public/endpoints/Invoices/edit.py
+++ b/backend/core/api/public/endpoints/Invoices/edit.py
@@ -3,10 +3,10 @@ from typing import Literal
 
 from rest_framework import status
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.types import APIRequest
+from backend.core.api.public.helpers.response import APIResponse
 from backend.finance.models import Invoice
 
 
@@ -15,20 +15,22 @@ from backend.finance.models import Invoice
 def edit_invoice_endpoint(request: APIRequest):
     invoice_id = request.data.get("invoice_id", "")
     if not invoice_id:
-        return Response({"error": "Invoice ID is required"}, status=status.HTTP_400_BAD_REQUEST)
+        return APIResponse(False, {"error": "Invoice ID is required"}, status=status.HTTP_400_BAD_REQUEST)
 
     try:
         invoice = Invoice.objects.get(id=invoice_id)
     except Invoice.DoesNotExist:
-        return Response({"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
+        return APIResponse(False, {"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
 
     if request.user.logged_in_as_team and request.user.logged_in_as_team != invoice.organization:
-        return Response(
+        return APIResponse(
+            False,
             {"error": "You do not have permission to edit this invoice"},
             status=status.HTTP_403_FORBIDDEN,
         )
     elif request.user != invoice.user:
-        return Response(
+        return APIResponse(
+            False,
             {"error": "You do not have permission to edit this invoice"},
             status=status.HTTP_403_FORBIDDEN,
         )
@@ -64,12 +66,12 @@ def edit_invoice_endpoint(request: APIRequest):
                 try:
                     new_value = datetime.strptime(new_value, "%Y-%m-%d").date()  # type: ignore[assignment]
                 except ValueError:
-                    return Response({"error": "Invalid date format for date_due"}, status=status.HTTP_400_BAD_REQUEST)
+                    return APIResponse(False, {"error": "Invalid date format for date_due"}, status=status.HTTP_400_BAD_REQUEST)
             setattr(invoice, column_name, new_value)
 
     invoice.save()
 
-    return Response({"message": "Invoice successfully edited"}, status=status.HTTP_200_OK)
+    return APIResponse(False, {"message": "Invoice successfully edited"}, status=status.HTTP_200_OK)
 
 
 @api_view(["POST"])
@@ -79,20 +81,20 @@ def change_status_endpoint(request, invoice_id: int, invoice_status: str):
     try:
         invoice = Invoice.objects.get(id=invoice_id)
     except Invoice.DoesNotExist:
-        return Response({"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
+        return APIResponse(False, {"error": "Invoice Not Found"}, status=status.HTTP_404_NOT_FOUND)
 
     if request.user.logged_in_as_team and request.user.logged_in_as_team != invoice.organization or request.user != invoice.user:
-        return Response({"error": "You do not have permission to edit this invoice"}, status=status.HTTP_403_FORBIDDEN)
+        return APIResponse(False, {"error": "You do not have permission to edit this invoice"}, status=status.HTTP_403_FORBIDDEN)
 
     if invoice_status not in ["paid", "draft", "pending"]:
-        return Response({"error": "Invalid status. Please choose from: pending, paid, draft"}, status=status.HTTP_400_BAD_REQUEST)
+        return APIResponse(False, {"error": "Invalid status. Please choose from: pending, paid, draft"}, status=status.HTTP_400_BAD_REQUEST)
 
     if invoice.status == invoice_status:
-        return Response({"error": f"Invoice status is already {invoice_status}"}, status=status.HTTP_400_BAD_REQUEST)
+        return APIResponse(False, {"error": f"Invoice status is already {invoice_status}"}, status=status.HTTP_400_BAD_REQUEST)
 
     invoice.set_status(invoice_status)
 
-    return Response({"message": f"Invoice status been changed to <strong>{invoice_status}</strong>"}, status=status.HTTP_200_OK)
+    return APIResponse(False, {"message": f"Invoice status been changed to <strong>{invoice_status}</strong>"}, status=status.HTTP_200_OK)
 
 
 @api_view(["POST"])
@@ -104,10 +106,10 @@ def edit_discount_endpoint(request, invoice_id: str):
     try:
         invoice: Invoice = Invoice.objects.get(id=invoice_id)
     except Invoice.DoesNotExist:
-        return Response({"error": "Invoice not found"}, status=status.HTTP_404_NOT_FOUND)
+        return APIResponse(False, {"error": "Invoice not found"}, status=status.HTTP_404_NOT_FOUND)
 
     if not invoice.has_access(request.user):
-        return Response({"error": "You don't have permission to make changes to this invoice."}, status=status.HTTP_403_FORBIDDEN)
+        return APIResponse(False, {"error": "You don't have permission to make changes to this invoice."}, status=status.HTTP_403_FORBIDDEN)
 
     if discount_type == "percentage":
         try:
@@ -115,7 +117,9 @@ def edit_discount_endpoint(request, invoice_id: str):
             if percentage_amount < 0 or percentage_amount > 100:
                 raise ValueError
         except ValueError:
-            return Response({"error": "Please enter a valid percentage amount (between 0 and 100)"}, status=status.HTTP_400_BAD_REQUEST)
+            return APIResponse(
+                False, {"error": "Please enter a valid percentage amount (between 0 and 100)"}, status=status.HTTP_400_BAD_REQUEST
+            )
         invoice.discount_percentage = percentage_amount
     else:
         try:
@@ -123,9 +127,9 @@ def edit_discount_endpoint(request, invoice_id: str):
             if discount_amount < 0:
                 raise ValueError
         except ValueError:
-            return Response({"error": "Please enter a valid discount amount"}, status=status.HTTP_400_BAD_REQUEST)
+            return APIResponse(False, {"error": "Please enter a valid discount amount"}, status=status.HTTP_400_BAD_REQUEST)
         invoice.discount_amount = discount_amount
 
     invoice.save()
 
-    return Response({"message": "Discount was applied successfully"}, status=status.HTTP_200_OK)
+    return APIResponse(False, {"message": "Discount was applied successfully"}, status=status.HTTP_200_OK)

--- a/backend/core/api/public/endpoints/Invoices/edit.py
+++ b/backend/core/api/public/endpoints/Invoices/edit.py
@@ -71,7 +71,7 @@ def edit_invoice_endpoint(request: APIRequest):
 
     invoice.save()
 
-    return APIResponse(False, {"message": "Invoice successfully edited"}, status=status.HTTP_200_OK)
+    return APIResponse(True, {"message": "Invoice successfully edited"}, status=status.HTTP_200_OK)
 
 
 @api_view(["POST"])
@@ -94,7 +94,7 @@ def change_status_endpoint(request, invoice_id: int, invoice_status: str):
 
     invoice.set_status(invoice_status)
 
-    return APIResponse(False, {"message": f"Invoice status been changed to <strong>{invoice_status}</strong>"}, status=status.HTTP_200_OK)
+    return APIResponse(True, {"message": f"Invoice status been changed to <strong>{invoice_status}</strong>"}, status=status.HTTP_200_OK)
 
 
 @api_view(["POST"])
@@ -132,4 +132,4 @@ def edit_discount_endpoint(request, invoice_id: str):
 
     invoice.save()
 
-    return APIResponse(False, {"message": "Discount was applied successfully"}, status=status.HTTP_200_OK)
+    return APIResponse(True, {"message": "Discount was applied successfully"}, status=status.HTTP_200_OK)

--- a/backend/core/api/public/endpoints/Invoices/get.py
+++ b/backend/core/api/public/endpoints/Invoices/get.py
@@ -2,6 +2,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.serializers.invoices import InvoiceSerializer
@@ -45,7 +46,7 @@ from backend.finance.models import Invoice
 )
 @api_view(["GET"])
 @require_scopes(["invoices:read"])
-def get_invoices_endpoint(request: APIRequest, id: str) -> APIResponse:
+def get_invoices_endpoint(request: APIRequest, id: str) -> Response:
     try:
         if request.team:
             invoices = Invoice.objects.filter(organization=request.team, id=id)

--- a/backend/core/api/public/endpoints/Invoices/get.py
+++ b/backend/core/api/public/endpoints/Invoices/get.py
@@ -2,12 +2,12 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import status
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.serializers.invoices import InvoiceSerializer
 from backend.core.api.public.swagger_ui import TEAM_PARAMETER
 from backend.core.api.public.types import APIRequest
+from backend.core.api.public.helpers.response import APIResponse
 from backend.finance.models import Invoice
 
 
@@ -45,15 +45,15 @@ from backend.finance.models import Invoice
 )
 @api_view(["GET"])
 @require_scopes(["invoices:read"])
-def get_invoices_endpoint(request: APIRequest, id: str) -> Response:
+def get_invoices_endpoint(request: APIRequest, id: str) -> APIResponse:
     try:
         if request.team:
             invoices = Invoice.objects.filter(organization=request.team, id=id)
         else:
             invoices = Invoice.objects.filter(user=request.user, id=id)
     except Invoice.DoesNotExist:
-        return Response({"success": False, "message": "Invoice not found"}, status=status.HTTP_400_BAD_REQUEST)
+        return APIResponse(False, {"message": "Invoice not found"}, status=status.HTTP_400_BAD_REQUEST)
 
     serializer = InvoiceSerializer(invoices, many=True)
 
-    return Response({"success": True, "invoice": serializer.data}, status=status.HTTP_200_OK)
+    return APIResponse(True, {"invoice": serializer.data}, status=status.HTTP_200_OK)

--- a/backend/core/api/public/endpoints/clients/delete.py
+++ b/backend/core/api/public/endpoints/clients/delete.py
@@ -3,13 +3,13 @@ from typing import Literal
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import api_view
-from rest_framework.response import Response
 
 from backend.core.api.public.decorators import require_scopes
 from backend.core.api.public.swagger_ui import TEAM_PARAMETER
 from backend.core.api.public.types import APIRequest
 
 from backend.core.service.clients.delete import delete_client, DeleteClientServiceResponse
+from backend.core.api.public.helpers.response import APIResponse
 
 
 @swagger_auto_schema(
@@ -64,5 +64,5 @@ def client_delete_endpoint(request: APIRequest, id: str):
     response: DeleteClientServiceResponse = delete_client(request, id)
 
     if response.failed:
-        return Response({"success": False, "message": response.error}, status=403 if "do not have permission" in response.error else 404)
-    return Response({"success": True, "client_id": id}, status=200)
+        return APIResponse(False, response.error, status=403 if "do not have permission" in response.error else 404)
+    return APIResponse(True, {"client_id": id}, status=200)

--- a/backend/core/api/public/endpoints/system_health.py
+++ b/backend/core/api/public/endpoints/system_health.py
@@ -4,9 +4,9 @@ from django.db import connection, OperationalError
 from django.core.cache import cache
 
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.response import Response
 
 from backend.core.api.public.permissions import IsSuperuser
+from backend.core.api.public.helpers.response import APIResponse
 
 
 @swagger_auto_schema(
@@ -46,7 +46,7 @@ from backend.core.api.public.permissions import IsSuperuser
 @permission_classes([IsSuperuser])
 def system_health_endpoint(request):
     if not request.user or not request.user.is_superuser:
-        return Response({"success": False, "message": "User is not permitted to view internal information"}, status=403)
+        return APIResponse(False, "User is not permitted to view internal information", status=403)
 
     problems = []
 
@@ -60,4 +60,4 @@ def system_health_endpoint(request):
     except ConnectionError:
         problems.append({"id": "redis", "message": "redis failed to connect"})
 
-    return Response({"problems": problems, "healthy": not bool(problems)})
+    return APIResponse({"problems": problems, "healthy": not bool(problems)})

--- a/backend/core/api/public/endpoints/webhooks/webhook_task_queue_handler.py
+++ b/backend/core/api/public/endpoints/webhooks/webhook_task_queue_handler.py
@@ -1,9 +1,9 @@
-from rest_framework.response import Response
 import logging
 from backend.core.api.public import APIAuthToken
 from rest_framework.decorators import api_view
 
 from backend.core.service.asyn_tasks.tasks import Task
+from backend.core.api.public.helpers.response import APIResponse
 
 
 @api_view(["POST"])
@@ -11,10 +11,10 @@ def webhook_task_queue_handler_view_endpoint(request):
     token: APIAuthToken | None = request.auth
 
     if not token:
-        return Response({"status": "error", "message": "No token found"}, status=500)
+        return APIResponse(False, {"status": "error", "message": "No token found"}, status=500)
 
     if not token.administrator_service_type == token.AdministratorServiceTypes.AWS_WEBHOOK_CALLBACK:
-        return Response({"status": "error", "message": "Invalid API key for this service"}, status=500)
+        return APIResponse(False, {"status": "error", "message": "Invalid API key for this service"}, status=500)
 
     try:
         data: dict = request.data
@@ -39,8 +39,8 @@ def webhook_task_queue_handler_view_endpoint(request):
         # Handle the result (e.g., store it or log it)
         print(f"Webhook executed: {func_name} with result: {result}")
 
-        return Response({"status": "success", "result": result})
+        return APIResponse(True, {"status": "success", "result": result})
 
     except Exception as e:
         logging.error(f"Error executing webhook task: {str(e)}")
-        return Response({"status": "error", "message": "An internal error has occurred."}, status=500)
+        return APIResponse(False, {"status": "error", "message": "An internal error has occurred."}, status=500)


### PR DESCRIPTION
## Description
Resolves #517 

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR focuses on standardizing the response format by replacing `Response` with `APIResponse`. This change ensures consistency in how API responses are structured and handled.

Key changes include:

* Replaced `Response` with `APIResponse` in `def _wrapped_view` to handle authentication and permission errors consistently (`backend/core/api/public/decorators.py`).
* Updated the `delete_invoice_endpoint` to use `APIResponse` for handling invoice deletion outcomes (`backend/core/api/public/endpoints/Invoices/delete.py`).
* Modified `download` to use `APIResponse` for handling PDF generation errors (`backend/core/api/public/endpoints/Invoices/download_pdf.py`).
* Updated `edit_invoice_endpoint` to use `APIResponse` for handling invoice editing outcomes (`backend/core/api/public/endpoints/Invoices/edit.py`). 
* Changed `get_invoices_endpoint` to use `APIResponse` for handling invoice retrieval results (`backend/core/api/public/endpoints/Invoices/get.py`).
* Updated `client_delete_endpoint` to use `APIResponse` for handling client deletion outcomes (`backend/core/api/public/endpoints/clients/delete.py`).
* Modified `system_health_endpoint` to use `APIResponse` for handling system health check results (`backend/core/api/public/endpoints/system_health.py`). 
* Updated `webhook_task_queue_handler_view_endpoint` to use `APIResponse` for handling webhook task outcomes (`backend/core/api/public/endpoints/webhooks/webhook_task_queue_handler.py`).

# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [ ] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?

- 🐛 Bug Fix
- ♻️ Code Refactor

## Added/updated tests?
<!-- delete all that don't apply -->
- 🙅 no, because they aren't needed

## Related PRs, Issues etc
- Related Issue #517
- Closes #517