### PR TITLE
Feature regen api keys

### DIFF
--- a/backend/core/api/settings/api_keys.py
+++ b/backend/core/api/settings/api_keys.py
@@ -56,6 +56,49 @@ def generate_api_key_endpoint(request: WebRequest) -> HttpResponse:
     return http_response
 
 
+@require_http_methods(["POST"])
+@web_require_scopes("api_keys:write")
+def regenerate_api_key_endpoint(request: WebRequest, key_id: str) -> HttpResponse:
+    key: APIAuthToken | None = get_api_key_by_id(request.user.logged_in_as_team or request.user, key_id)
+
+    if not key:
+        messages.error(request, "API key not found")
+        return render(request, "base/toast.html")
+
+    delete_api_key(request, request.user.logged_in_as_team or request.user, key=key)
+
+    key_obj, new_key_response = generate_public_api_key(
+        request,
+        request.user.logged_in_as_team or request.user,
+        api_key_name=key.name,
+        permissions=key.scopes,
+        expires=key.expires,
+        description=key.description,
+        administrator_toggle=bool(key.administrator_service_type),
+        administrator_type=key.administrator_service_type,
+    )
+
+    if not key_obj:
+        messages.error(request, f"Failed to regenerate the API key: {new_key_response}")
+        return render(request, "base/toast.html")
+
+    messages.success(request, "API key regenerated successfully")
+
+    http_response = render(
+        request,
+        "pages/settings/settings/api_key_generated_response.html",
+        {
+            "raw_key": new_key_response,
+            "name": key.name,
+        },
+    )
+
+    http_response.headers["HX-Reswap"] = "beforebegin"
+    http_response.headers["HX-Retarget"] = 'div[data-hx-container="api_keys"]'
+
+    return http_response
+
+
 @require_http_methods(["DELETE"])
 def revoke_api_key_endpoint(request: WebRequest, key_id: str) -> HttpResponse:
     key: APIAuthToken | None = get_api_key_by_id(request.user.logged_in_as_team or request.user, key_id)

--- a/backend/core/api/settings/urls.py
+++ b/backend/core/api/settings/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from . import change_name, profile_picture, preferences
-from .api_keys import generate_api_key_endpoint, revoke_api_key_endpoint
+from .api_keys import generate_api_key_endpoint, revoke_api_key_endpoint, regenerate_api_key_endpoint
 from .defaults import handle_client_defaults_endpoints, remove_client_default_logo_endpoint
 from .email_templates import save_email_template
 
@@ -18,6 +18,7 @@ urlpatterns = [
     ),
     path("profile_picture/", profile_picture.change_profile_picture_endpoint, name="update profile picture"),
     path("api_keys/generate/", generate_api_key_endpoint, name="api_keys generate"),
+    path("api_keys/regenerate/<str:key_id>/", regenerate_api_key_endpoint, name="api_keys regenerate"),
     path("api_keys/revoke/<str:key_id>/", revoke_api_key_endpoint, name="api_keys revoke"),
     path("client_defaults/<int:client_id>/", handle_client_defaults_endpoints, name="client_defaults"),
     path("client_defaults/", handle_client_defaults_endpoints, name="client_defaults without client"),

--- a/frontend/templates/pages/settings/settings/api_key_row.html
+++ b/frontend/templates/pages/settings/settings/api_key_row.html
@@ -4,6 +4,10 @@
     <td>{{ key.expires | date:"d M, Y" | default:"Never" }}</td>
     <td>{{ key.created | date:"d M, Y H:iA" }}</td>
     <td>
+        <button class="btn btn-warning btn-sm"
+                hx-post="{% url 'api:settings:api_keys regenerate' key_id=key.id %}"
+                hx-target="closest tr"
+                hx-swap="outerHTML">Regenerate</button>
         <button class="btn btn-error btn-sm"
                 hx-delete="{% url 'api:settings:api_keys revoke' key_id=key.id %}"
                 hx-target="closest tr"

--- a/tests/api/test_regenerate_api_key.py
+++ b/tests/api/test_regenerate_api_key.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from django.urls import reverse
+from backend.models import User
+from backend.core.api.public import APIAuthToken
+
+
+class RegenerateAPIKeyTestCase(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="user@example.com",
+            password="user",
+            email="user@example.com",
+            entitlements=["api-access", "api_keys:write"],
+            is_superuser=False,
+        )
+        self.user.save()
+        self.client.login(username="user@example.com", password="user")
+        self.api_key = APIAuthToken.objects.create(
+            user=self.user, name="Test Key", scopes=["api_keys:write"], description="Test Description"
+        )
+        self.url = reverse("api:settings:api_keys regenerate", args=[self.api_key.id])
+
+    def test_regenerate_api_key_success(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "API key regenerated successfully")
+        self.assertTrue(APIAuthToken.objects.filter(name="Test Key").exists())
+
+    def test_regenerate_nonexistent_api_key(self):
+        invalid_url = reverse("api:settings:api_keys regenerate", args=[999999])
+        response = self.client.post(invalid_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "API key not found")
+
+    def test_regenerate_api_key_invalid_method(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 405)
+
+    def tearDown(self):
+        APIAuthToken.objects.all().delete()
+        self.user.delete()


### PR DESCRIPTION
## Description
Added an endpoint to regenerate an existing api key and related button in the frontend. 

Preferably this button would have a confirmation dialog to confirm the regen instead of immediately doing so, but I'm not great with frontend stuff, so any thoughts or work is appreciated.

# Checklist

- [x] Ran the [Black Formatter](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) and
  [djLint-er](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) on any new code
  (checks
  will
  fail without)
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](https://docs.strelix.org/MyFinances/#/how-to-contribute?id=test-and-lint) pass locally with my
  changes


## What type of PR is this?
<!-- delete all that don't apply -->
- ✨ Feature

## Added/updated tests?
- 👍 yes

## Related PRs, Issues etc
- Related Issue #524
- Closes #524
