### PR TITLE
Make the button style at Invoices page uniform.

### DIFF
--- a/frontend/templates/pages/invoices/dashboard/manage.html
+++ b/frontend/templates/pages/invoices/dashboard/manage.html
@@ -38,11 +38,11 @@
                 hx-swap="none"
                 hx-confirm="Are you sure you would like to delete invoice #{{ invoice.id }}?"
                 hx-vals='{"invoice": "{{ invoice.id }}", "redirect": "/dashboard/invoices/"}'
-                class="btn btn-sm btn-outline btn-error float-right">
+                class="btn btn-sm btn-outline btn-error h-10 flex-nowrap w-fit gap-2 whitespace-nowrap ml-auto">
             <i class="fa-solid fa-trash"></i>
-            Delete
+            <span>Delete</span>
         </button>
-        <a class="btn btn-sm btn-outline btn-default loading-htmx"
+        <a class="btn btn-sm btn-outline btn-default h-10 flex-nowrap w-fit gap-2 whitespace-nowrap loading-htmx"
            target="_blank"
            rel="noopener noreferrer"
            href="{% url 'finance:invoices:single:preview' invoice_id=invoice.id %}">
@@ -53,26 +53,26 @@
             <span class="loading loading-spinner loading-htmx-loader"></span>
         </a>
         <a href="{% url "finance:invoices:single:edit" invoice_id=invoice.id %}"
-           class="btn btn-sm btn-outline btn-default">
+           class="btn btn-sm btn-outline btn-default h-10 flex-nowrap w-fit gap-2 whitespace-nowrap">
             <i class="fa-solid fa-edit"></i>
-            Edit Invoice
+            <span>Edit Invoice</span>
         </a>
         <a href="{% url "finance:invoices:single:manage_access" invoice_id=invoice.id %}"
-           class="btn btn-sm btn-outline btn-default">
+           class="btn btn-sm btn-outline btn-default h-10 flex-nowrap w-fit gap-2 whitespace-nowrap">
             <i class="fa-solid fa-share-nodes"></i>
-            Send Invoice
+            <span class="whitespace-nowrap">Send&nbsp;Invoice</span>
         </a>
         {% if schedule_invoices_enabled %}
             <a class="btn btn-outline btn-default btn-sm mr-4">
                 <i class="fa-solid fa-clock"></i>
-                Schedule Invoice
+                <span>Schedule Invoice</span>
             </a>
         {% endif %}
         <div class="basis-[100%] h-0"></div>
         <div class="dropdown dropdown-right dropdown-hover flex">
-            <div class="btn btn-primary btn-sm btn-outline" tabindex="0" role="button">
+            <div class="btn btn-primary btn-sm btn-outline h-10 flex-nowrap w-fit gap-2 whitespace-nowrap" tabindex="0" role="button">
                 <i class="fa-solid fa-flag"></i>
-                Mark As
+                <span class="whitespace-nowrap">Mark&nbsp;As</span>
             </div>
             <ul tabindex="0"
                 class="p-2 shadow menu dropdown-content z-[1] bg-base-100 rounded-box w-52 border border-base-300">
@@ -99,18 +99,18 @@
                 </li>
             </ul>
         </div>
-        <button class="btn btn-secondary btn-outline btn-sm"
+        <button class="btn btn-secondary btn-outline btn-sm h-10 flex-nowrap w-fit gap-2 whitespace-nowrap"
                 hx-trigger="click once"
                 hx-swap="beforeend"
                 hx-target="#modal_container"
                 _="on click call modal_invoices_edit_discount.showModal()"
                 hx-get="{% url "api:base:modal retrieve with context" context_type="invoice" context_value=invoice.id modal_name="invoices_edit_discount" %}">
             <i class="fa fa-solid fa-pound-sign mr-2"></i>
-            Edit Discount
+            <span>Edit Discount</span>
         </button>
-        <a class="btn btn-outline btn-sm" href="{{ clone_as_recurring_url }}">
+        <a class="btn btn-outline btn-sm h-10 flex-nowrap w-fit gap-2 whitespace-nowrap" href="{{ clone_as_recurring_url }}">
             <i class="fa fa-clone"></i>
-            Clone to Recurring Profile
+            <span>Clone to Recurring Profile</span>
         </a>
     </div>
     <div class="divider my-8"></div>


### PR DESCRIPTION
Some action buttons on **Invoice › Manage** were displaying their icon above the label  
(e.g. `Send Invoice`, `Mark As`), while others showed a left-to-right layout.  
The visual inconsistency was caused by:
1. DaisyUI’s default `.btn-sm` height (2 rem) being too small for our font size,  
2. `white-space` rules that allowed labels to wrap at spaces.

This pull-request normalises the buttons so that *every* button uses a single-line  
“icon + label” presentation.
I modified manage.html, adding utility classes: `h-10`, `flex-nowrap`, `w-fit`, `gap-2` for uniform height & spacing and adding `whitespace-nowrap` on label `<span>` to stop intra-label wrapping.
Now, the text will not run outside the border, and the images and text in all buttons are arranged in a left-right structure.

Before modification:
<img width="662" alt="before" src="https://github.com/user-attachments/assets/90b06326-f88f-44b5-990f-578d5eb13439" />

After modification:
<img width="1183" alt="after" src="https://github.com/user-attachments/assets/f281a930-b1b8-49d7-b91b-701bf54ce271" />
