### PR TITLE
docs: fix README docs link (Fixes #587)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ usual hosting platform, we have a docker setup.
 
 ### Installation
 
-For detailed setup instructions please refer to our documentation: [https://docs.strelix.org/MyFinances](https://docs.strelix.org/MyFinances)
+For detailed setup instructions please refer to our documentation: [https://myfinances-docs.strelix.cloud/](https://myfinances-docs.strelix.cloud/)
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Fixes #587

Updates the broken documentation link in README.md to point to
https://myfinances-docs.strelix.cloud/ instead of
https://docs.strelix.org/MyFinances.


# Checklist

- [x] Ran the [Black Formatter](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) and
  [djLint-er](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) on any new code
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 📝 Documentation Update


## Added/updated tests?
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue #
- Closes #587
