### PR TITLE
fix: correct typo in contributors table update command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ manually edit with the details below.
 
 ### How to edit the contributors table?
 
-- Updated any info using `python3 manage.py contriubtors`
+- Updated any info using `python3 manage.py contributors`
 - Run `python3 manage.py contributors sync`
 - Make a PR to request these changes in
 - Done :)


### PR DESCRIPTION
## Description


This pull request fixes a typo in the administrative command that allows you to update the contributors table in the `README.md` file.


# Checklist

- [ ] Ran the [Black Formatter](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) and
  [djLint-er](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) on any new code
- [x] Made any changes or additions to the documentation _where required_
- [ ] Changes generate no new warnings/errors
- [ ] New and existing [unit tests](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 📝 Documentation Update


## Added/updated tests?
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue #
- Closes # <!-- This automatically closes the issue upon merge -->
