### PR TITLE
Backend Docker build issue fix #596

### DIFF
--- a/infrastructure/backend/Dockerfile
+++ b/infrastructure/backend/Dockerfile
@@ -28,9 +28,9 @@ RUN if [ "${TESTING}" != "true" ] || [ "${DATABASE_TYPE}" = "postgres" ]; then \
         poetry install --only postgres; \
     fi
 
-RUN apk del .build-deps
+RUN poetry install --without dev,mysql,postgres --no-root 
 
-RUN poetry install --without dev,mysql,postgres --no-root && rm -rf $POETRY_CACHE_DIR
+RUN apk del .build-deps && rm -rf $POETRY_CACHE_DIR
 
 COPY . .
 


### PR DESCRIPTION
## Description

while building backend docker image , facing issue

```
  File "/usr/local/lib/python3.12/subprocess.py", line 1026, in __init__
31.20       self._execute_child(args, executable, preexec_fn, close_fds,
31.20     File "/usr/local/lib/python3.12/subprocess.py", line 1955, in _execute_child
31.20       raise child_exception_type(errno_num, err_msg, err_filename)
31.20   FileNotFoundError: [Errno 2] No such file or directory: 'c++'
31.20   
31.20 
31.20   at /usr/local/lib/python3.12/site-packages/poetry/installation/chef.py:164 in _prepare
31.21       160│ 
31.21       161│                 error = ChefBuildError("\n\n".join(message_parts))
31.21       162│ 
31.21       163│             if error is not None:
31.21     → 164│                 raise error from None
31.21       165│ 
31.21       166│             return path
31.21       167│ 
31.21       168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
31.21 
31.21 Note: This error originates from the build backend, and is likely not a problem with poetry but with grpcio (1.60.2) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "grpcio (==1.60.2)"'.
[+] Running 0/1
 ⠼ Service myfinances_django  Building                                                                                                                                                               154.4s 
failed to solve: process "/bin/sh -c poetry install --without dev,mysql,postgres --no-root && rm -rf $POETRY_CACHE_DIR" did not complete successfully: exit code: 1
```


## What type of PR is this?
- 🐛 Bug Fix


## Added/updated tests?
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue #596
