### PR TITLE
Update dependabot.yml to ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       interval: "weekly"
 
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "django-components"
+      - dependency-name: "black"
 
     groups:
       python-dependencies:
@@ -24,6 +30,10 @@ updates:
       interval: "weekly"
 
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
     groups:
       npm-dependencies:
@@ -36,6 +46,10 @@ updates:
       interval: "weekly"
 
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
     groups:
       docker-dependencies:


### PR DESCRIPTION
Ignore major updates for dependabot as it breaks functionality

Also exclude: black, django-components