### PR TITLE
Fix team-owned invoice edit permissions

### DIFF
--- a/backend/finance/api/invoices/edit.py
+++ b/backend/finance/api/invoices/edit.py
@@ -19,12 +19,7 @@ def edit_invoice(request: HtmxHttpRequest):
     except Invoice.DoesNotExist:
         return JsonResponse({"message": "Invoice not found"}, status=404)
 
-    if request.user.logged_in_as_team and request.user.logged_in_as_team != invoice.organization:
-        return JsonResponse(
-            {"message": "You do not have permission to edit this invoice"},
-            status=403,
-        )
-    elif request.user != invoice.user:
+    if not invoice.has_access(request.user):
         return JsonResponse(
             {"message": "You do not have permission to edit this invoice"},
             status=403,

--- a/tests/api/test_invoices.py
+++ b/tests/api/test_invoices.py
@@ -115,6 +115,66 @@ class InvoicesAPIDelete(ViewTestCase):
     # self.assertEqual(response_content.get("message"), "Invoice not found")
 
 
+class InvoicesAPIEdit(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        self.url_path = "/api/invoices/single/edit/"
+        self.url_name = "api:finance:invoices:single:edit"
+        self.view_function_path = "backend.finance.api.invoices.edit.edit_invoice"
+
+    def test_matches_with_urls_view(self):
+        assert_url_matches_view(
+            self.url_path,
+            self.url_name,
+            self.view_function_path,
+        )
+
+    def test_user_cannot_edit_team_owned_invoice_without_team_context(self):
+        self.login_user()
+
+        invoice: Invoice = baker.make(
+            "backend.Invoice",
+            organization=self.created_team,
+            user=None,
+            self_name="Before edit",
+        )
+
+        response = self.client.post(
+            reverse(self.url_name),
+            {"invoice_id": invoice.id, "from_name": "After edit"},
+            **self.htmx_headers,
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.self_name, "Before edit")
+
+    def test_team_member_can_edit_team_owned_invoice(self):
+        self.login_to_team()
+        invoice: Invoice = baker.make(
+            "backend.Invoice",
+            organization=self.created_team,
+            user=None,
+            self_name="Before edit",
+        )
+
+        response = self.client.post(
+            reverse(self.url_name),
+            {"invoice_id": invoice.id, "from_name": "After edit"},
+            **self.htmx_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.self_name, "After edit")
+
+        messages = self.get_all_messages(response)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), "Invoice edited")
+
+
 class InvoicesEditDiscount(ViewTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Description

Fixes a permission bug in the invoice edit endpoint for team-owned invoices.

The endpoint previously performed manual permission checks against both the active team and the invoice user. For team-owned invoices, `invoice.organization` is set while `invoice.user` may be empty. This meant that a user logged in as the owning team could still be incorrectly rejected with a 403 response.

This PR replaces the duplicated manual permission check with the existing `invoice.has_access(request.user)` helper, which already handles both personal and team-owned invoices.

Regression tests were added for:
- allowing a team member to edit an invoice owned by their active team
- rejecting a user who is not currently acting in the matching team context

No new dependencies are required.


# Checklist

- [x] Ran the [Black Formatter](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) and
  [djLint-er](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) on any new code
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) pass locally with my
  changes


## What type of PR is this?

- 🐛 Bug Fix

## Added/updated tests?

- 👍 yes


## Related PRs, Issues etc

- Related Issue: N/A

