### PR TITLE
Fix notification dropdown does not show all notifications after deletion issue

### DIFF
--- a/backend/core/api/base/notifications.py
+++ b/backend/core/api/base/notifications.py
@@ -6,6 +6,7 @@ from backend.models import Notification
 from backend.core.types.htmx import HtmxHttpRequest
 
 
+
 def get_notification_html(request: HtmxHttpRequest):
     user_notifications = Notification.objects.filter(user=request.user).order_by("-date")
     count = user_notifications.count()
@@ -22,7 +23,10 @@ def get_notification_html(request: HtmxHttpRequest):
 
 def get_notification_count_html(request: HtmxHttpRequest):
     user_notifications = Notification.objects.filter(user=request.user).count()
-    return HttpResponse(f"{user_notifications}")
+    response =  HttpResponse(f"{user_notifications}")
+    if user_notifications > 4 or user_notifications == 0:
+        response["HX-Trigger"] = "update_notifications"
+    return response
 
 
 def delete_notification(request: HtmxHttpRequest, id: int):

--- a/frontend/templates/base/topbar/_notification_dropdown_items.html
+++ b/frontend/templates/base/topbar/_notification_dropdown_items.html
@@ -37,6 +37,7 @@
             <a tabindex="-1"
                class="dropdown-item text-sm {% if not forloop.first %}mt-1{% endif %}"
                hx-delete="{% url 'api:base:notifications delete' id=notification.id %}"
+               hx-target="this"
                hx-swap="outerHTML">{{ notification.message }}</a>
         </li>
     {% elif notification.action == "redirect" %}

--- a/frontend/templates/base/topbar/_topbar.html
+++ b/frontend/templates/base/topbar/_topbar.html
@@ -105,7 +105,11 @@
             {% include "base/topbar/_notification_count.html" %}
         </summary>
         <ul class="border menu menu-sm dropdown-content border-primary"
-            data-notifications="container">
+            data-notifications="container"
+            hx-trigger="update_notifications from:body"
+            hx-get="{% url "api:base:notifications get" %}"
+            hx-target="this"
+            hx-swap="innerHTML">
             {% include "base/topbar/_notification_dropdown_items.html" with initial_load=True %}
         </ul>
     </details>


### PR DESCRIPTION
## Description

Fixed the issue by triggering full list reload in update_notifications view via "HX-Trigger: update_notifications" only when there are hidden notifications (count > 5) and when there are no notifications (count == 0).


# Checklist

- [x] Ran the [Black Formatter](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) and
  [djLint-er](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) on any new code
- [ ] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) pass locally with my
  changes


## What type of PR is this?
- 🐛 Bug Fix


## Added/updated tests?
- 🙅 no, because they aren't needed


## Related PRs, Issues etc
- Related Issue #559 
- Closes #559 
