### PR TITLE
fix: remove leftover debug print from invoice create page

### DIFF
--- a/backend/finance/views/invoices/single/create.py
+++ b/backend/finance/views/invoices/single/create.py
@@ -54,8 +54,6 @@ def create_invoice_page_endpoint(request: WebRequest):
         except Invoice.DoesNotExist:
             messages.error(request, "Invoice to clone not found")
 
-    print(context)
-
     return invoices_core_handler(request, "pages/invoices/create/create_single.html", context)
 
 


### PR DESCRIPTION
Removes a stray `print(context)` debug statement left in the `create_invoice_page_endpoint` view.