### PR TITLE
fix: BotoSchedule.set_status writes to wrong field name

### DIFF
--- a/backend/finance/models.py
+++ b/backend/finance/models.py
@@ -36,7 +36,7 @@ class BotoSchedule(models.Model):
         abstract = True
 
     def set_status(self, status, save=True):
-        self.status = status
+        self.boto_schedule_status = status
         if save:
             self.save()
         return self

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -121,7 +121,7 @@ npm run tailwind-watch
 
 #### Tailwind Build
 
-To be honest, tailwind watch is nice, but especially on my windows computer it is very CPU and Memory intesive, every single change,
+To be honest, tailwind watch is nice, but especially on my windows computer it is very CPU and Memory intensive, every single change,
 even 1 character causes a re-watch, and this is a lot... Instead of that, you can use `tailwind-build` to only do a one-time
 build. You need to remember to run the command after a major update though, incase you add new classes.
 


### PR DESCRIPTION
BotoSchedule.set_status() was setting `self.status` but the actual DB field is `boto_schedule_status`. This meant schedule status updates (used by InvoiceReminder and InvoiceRecurringProfile) silently wrote to a non-persistent dynamic attribute instead of the database column.