### PR TITLE
fix: prevent month overflow crash in recurring invoice date calculations

### DIFF
--- a/backend/finance/models.py
+++ b/backend/finance/models.py
@@ -3,6 +3,7 @@ from datetime import datetime, date, timedelta
 from decimal import Decimal
 from typing import Literal
 from uuid import uuid4
+from dateutil.relativedelta import relativedelta
 from django.core.validators import MaxValueValidator
 from django.db import models
 from django.utils import timezone
@@ -282,7 +283,7 @@ class InvoiceRecurringProfile(InvoiceBase, BotoSchedule):
             case "weekly":
                 return last_invoice_date_issued + timedelta(days=7)
             case "monthly":
-                return date(year=last_invoice_date_issued.year, month=last_invoice_date_issued.month + 1, day=last_invoice_date_issued.day)
+                return last_invoice_date_issued + relativedelta(months=1)
             case "yearly":
                 return date(year=last_invoice_date_issued.year + 1, month=last_invoice_date_issued.month, day=last_invoice_date_issued.day)
             case _:
@@ -293,7 +294,7 @@ class InvoiceRecurringProfile(InvoiceBase, BotoSchedule):
             case account_defaults.InvoiceDueDateType.days_after:
                 return from_date + timedelta(days=account_defaults.invoice_due_date_value)
             case account_defaults.InvoiceDueDateType.date_following:
-                return datetime(from_date.year, from_date.month + 1, account_defaults.invoice_due_date_value)
+                return (from_date + relativedelta(months=1)).replace(day=account_defaults.invoice_due_date_value)
             case account_defaults.InvoiceDueDateType.date_current:
                 return datetime(from_date.year, from_date.month, account_defaults.invoice_due_date_value)
             case _:


### PR DESCRIPTION
Two fixes in recurring invoice date calculation that crash with ValueError when the current month is December:

1. **next_invoice_issue_date** (monthly frequency): Used  which produces month=13 in December. Now uses  which handles month wrapping correctly.

2. **next_invoice_due_date** (date_following type): Same month+1 overflow via . Now uses  with .

python-dateutil is already a project dependency.