### PR TITLE
feat: use invoice reference for print filename

### DIFF
--- a/frontend/templates/pages/invoices/single/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/single/view/invoice_page.html
@@ -211,6 +211,21 @@
                 }
             }
                 </style>
+                <script>
+                    (function () {
+                        const printFilename = "MyFinances-invoice-{{ invoice.reference|default:invoice.id|escapejs }}.pdf";
+                        let originalTitle = document.title;
+
+                        window.addEventListener("beforeprint", function () {
+                            originalTitle = document.title;
+                            document.title = printFilename;
+                        });
+
+                        window.addEventListener("afterprint", function () {
+                            document.title = originalTitle;
+                        });
+                    })();
+                </script>
             </main>
         </div>
     </body>

--- a/frontend/templates/pages/invoices/single/view/invoice_page.html
+++ b/frontend/templates/pages/invoices/single/view/invoice_page.html
@@ -215,14 +215,19 @@
                     (function () {
                         const printFilename = "MyFinances-invoice-{{ invoice.reference|default:invoice.id|escapejs }}.pdf";
                         let originalTitle = document.title;
+                        let originalWindowTitle = window.parent.document.title;
 
                         window.addEventListener("beforeprint", function () {
                             originalTitle = document.title;
+                            originalWindowTitle = window.parent.document.title;
+
+                            window.parent.document.title = printFilename;
                             document.title = printFilename;
                         });
 
                         window.addEventListener("afterprint", function () {
                             document.title = originalTitle;
+                            window.parent.document.title = originalWindowTitle;
                         });
                     })();
                 </script>


### PR DESCRIPTION
## Description

This change will use an invoice's reference for the print filename.


# Checklist

- [x] Ran the [Black Formatter](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) and
  [djLint-er](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) on any new code
- [x] Made any changes or additions to the documentation _where required_
- [x] Changes generate no new warnings/errors
- [x] New and existing [unit tests](http://strelix.link/myfinances-docs/contributing/setup/#test-and-lint) pass locally with my
  changes


## What type of PR is this?

- ✨ Feature


## Added/updated tests?

- 🙅 no, because they aren't needed


## Related PRs, Issues etc

- Closes #707
