### PR TITLE
fix: prevent invoice action dropdown clipping in scrollable tables

### DIFF
--- a/frontend/templates/pages/invoices/dashboard/_fetch_body.html
+++ b/frontend/templates/pages/invoices/dashboard/_fetch_body.html
@@ -55,7 +55,7 @@
                         <i class="fa-solid fa-ellipsis-vertical"></i>
                     </label>
                     <ul tabindex="0"
-                        class="dropdown-content z-[1] menu wp-2 shadow-2xl bg-base-200 rounded-box w-52">
+                        class="dropdown-content z-50 menu wp-2 shadow-2xl bg-base-200 rounded-box w-52">
                         <li hx-boost="true"
                             hx-push-url="{% url 'finance:invoices:single:overview' invoice_id=invoice.id %}">
                             <a href="{% url 'finance:invoices:single:overview' invoice_id=invoice.id %}">

--- a/frontend/templates/pages/invoices/recurring/dashboard/_fetch_body.html
+++ b/frontend/templates/pages/invoices/recurring/dashboard/_fetch_body.html
@@ -47,7 +47,7 @@
                         <i class="fa-solid fa-ellipsis-vertical"></i>
                     </label>
                     <ul tabindex="0"
-                        class="dropdown-content z-[1] menu wp-2 shadow-2xl bg-base-200 border border-base-300 rounded-box w-52">
+                        class="dropdown-content z-50 menu wp-2 shadow-2xl bg-base-200 border border-base-300 rounded-box w-52">
                         <li hx-boost="true">
                             <a href="{% url "finance:invoices:recurring:overview" invoice_profile_id=invoiceProfile.id %}">
                                 <i class="fa-solid fa-eye"></i>

--- a/frontend/templates/pages/invoices/recurring/dashboard/dashboard.html
+++ b/frontend/templates/pages/invoices/recurring/dashboard/dashboard.html
@@ -53,7 +53,7 @@
 <div class="card bg-base-100 p-6 h-screen">
     <form id="page_storage">
     </form>
-    <div class="flex w-full h-full overflow-x-auto overflow-y-auto">
+    <div class="flex w-full h-full overflow-x-auto">
         <table class="table h-fit" id="recurring_invoices_list_table">
             <thead>
                 <tr>

--- a/frontend/templates/pages/invoices/single/dashboard/dashboard.html
+++ b/frontend/templates/pages/invoices/single/dashboard/dashboard.html
@@ -62,7 +62,7 @@
     </div>
 </div>
 <div class="card bg-base-100 p-6 h-screen">
-    <div class="flex w-full h-full overflow-x-auto overflow-y-auto">
+    <div class="flex w-full h-full overflow-x-auto">
         <table class="table h-fit"
                id="single_invoices_list_table"
                hx-swap="outerHTML"


### PR DESCRIPTION
## Problem

Invoice action dropdowns (the ⋮ menu on each row) get clipped when the table is long enough to scroll. From invoice 5+ onwards, the dropdown is partially hidden.

## Root cause

The table containers have overflow-x-auto and overflow-y-auto on the wrapper div. In CSS, any overflow value other than visible creates an overflow context that physically clips absolutely-positioned children — regardless of z-index. The DaisyUI dropdown-content is position: absolute, so it gets clipped by the scrollable parent.

## Fix

- Remove overflow-y-auto from the table wrapper divs (both single and recurring invoice dashboards). Tables still scroll horizontally via overflow-x-auto.
- Bump dropdown z-index from z-[1] to z-50 for stacking safety.

4 files, 4 line changes. No JS, no new dependencies.

## Testing

Verified dropdowns render fully on both single and recurring invoice dashboards with 10+ invoices.